### PR TITLE
Patch to add support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ add it, if you think that would be useful.
 
 ## Usage
 
-Ansible doesn't (seem to) support calling the inventory script with parameters
-(and this tool doesn't support configuration via environment variables yet), so
-I like to create a little shell script and call that. Something like:
+Ansible doesn't (seem to) support calling the inventory script with parameters,
+so you can specify the path to the state file using the environment variable
+TI\_TFSTATE like so:
+
+  TI\_TFSTATE=deploy/terraform.tfstate ansible-playbook --inventory-file=terraform-inventory
+
+Alternately, you can create a little shell script and call that. Something like:
 
 	#!/bin/bash
 	terraform-inventory $@ deploy/terraform.tfstate

--- a/cli.go
+++ b/cli.go
@@ -20,7 +20,7 @@ func cmdList(stdout io.Writer, stderr io.Writer, s *state) int {
 
 func cmdHost(stdout io.Writer, stderr io.Writer, s *state, hostname string) int {
 	for _, inst := range s.instances() {
-		if hostname ==  inst.Attributes["private_ip"] {
+		if hostname == inst.Attributes["private_ip"] {
 			return output(stdout, stderr, inst.Attributes)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	env "github.com/danryan/env"
 	"os"
 	"path/filepath"
 )
@@ -11,9 +12,15 @@ var version = flag.Bool("version", false, "print version information and exit")
 var list = flag.Bool("list", false, "list mode")
 var host = flag.String("host", "", "host mode")
 
+type Config struct {
+	TfState string `env:"key=TI_TFSTATE"`
+}
+
 func main() {
 	flag.Parse()
 	file := flag.Arg(0)
+	cfg := &Config{}
+	env.MustProcess(cfg)
 
 	if *version == true {
 		fmt.Printf("%s version %d\n", os.Args[0], versionInfo())
@@ -21,8 +28,12 @@ func main() {
 	}
 
 	if file == "" {
-		fmt.Printf("Usage: %s [options] path\n", os.Args[0])
-		os.Exit(1)
+		if cfg.TfState == "" {
+			fmt.Printf("Usage: %s [options] path\n", os.Args[0])
+			os.Exit(1)
+		} else {
+			file = cfg.TfState
+		}
 	}
 
 	if !*list && *host == "" {

--- a/parser.go
+++ b/parser.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"io"
 	"io/ioutil"
-	"encoding/json"
 	"strings"
 )
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/stretchr/testify/assert"
-	"testing"
 	"strings"
+	"testing"
 )
 
 const exampleStateFile = `
@@ -70,7 +70,7 @@ func TestStateRead(t *testing.T) {
 							ID: "i-aaaaaaaa",
 							Attributes: map[string]string{
 								"ami": "ami-XXXXXXXX",
-								"id": "i-aaaaaaaa",
+								"id":  "i-aaaaaaaa",
 							},
 						},
 					},
@@ -80,7 +80,7 @@ func TestStateRead(t *testing.T) {
 							ID: "i-bbbbbbbb",
 							Attributes: map[string]string{
 								"ami": "ami-YYYYYYYY",
-								"id": "i-bbbbbbbb",
+								"id":  "i-bbbbbbbb",
 							},
 						},
 					},
@@ -90,7 +90,7 @@ func TestStateRead(t *testing.T) {
 							ID: "sg-cccccccc",
 							Attributes: map[string]string{
 								"description": "Whatever",
-								"id": "sg-cccccccc",
+								"id":          "sg-cccccccc",
 							},
 						},
 					},


### PR DESCRIPTION
This change is admittedly overkill for just defining the state path.
However, this opens the door for additional configuration options 
to be defined in environment variables such as choosing the keys 
to match on for the "host" argument.