### PR TITLE
Added GCE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a little Go app which generates an dynamic [Ansible] [ansible] inventory
 from a [Terraform] [tf] state file. It allows one to spawn a bunch of instances
 with Terraform, then (re-)provision them with Ansible. Currently, only **AWS**,
-**DigitalOcean**, **CloudStack**, **VMware**, and **OpenStack** are supported.
+**DigitalOcean**, **CloudStack**, **VMware**, **OpenStack**, **Google Compute Engine** are supported.
 
 
 # Installation

--- a/resource.go
+++ b/resource.go
@@ -22,6 +22,8 @@ func init() {
 		"ip_address",   // VMware
 		"access_ip_v4", // OpenStack
 		"floating_ip",  // OpenStack
+		"network_interface.0.access_config.0.nat_ip", // GCE
+		"network_interface.0.address", // GCE
 	}
 
 	// type.name.0


### PR DESCRIPTION
Added GCE support based on the terraform state file example below.

```
{
    "version": 1,
    "serial": 1,
    "modules": [
        {
            "path": [
                "root"
            ],
            "outputs": {},
            "resources": {}
        },
        {
            "path": [
                "root",
                "gce-dc"
            ],
            "outputs": {
                "dbhost_ips": "1.1.1.1"
            },
            "resources": {
                "google_compute_disk.dbcluster-lvm": {
                    "type": "google_compute_disk",
                    "primary": {
                        "id": "db-lvm-01",
                        "attributes": {
                            "id": "db-lvm-01",
                            "name": "db-lvm-01",
                            "self_link": "https://www.googleapis.com/compute/v1/projects",
                            "size": "20",
                            "type": "pd-ssd",
                            "zone": "europe-west1-b"
                        }
                    }
                },
                "google_compute_firewall.db-firewall-ext": {
                    "type": "google_compute_firewall",
                    "depends_on": [
                        "google_compute_network.db-network"
                    ],
                    "primary": {
                        "id": "db-firewall-ext",
                        "attributes": {
                            "allow.#": "2",
                            "allow.1367131964.ports.#": "0",
                            "allow.1367131964.protocol": "icmp",
                            "allow.803338340.ports.#": "1",
                            "allow.803338340.ports.1685985038": "22",
                            "allow.803338340.protocol": "tcp",
                            "id": "db-firewall-ext",
                            "name": "db-firewall-ext",
                            "network": "dbcluster",
                            "self_link": "https://www.googleapis.com/compute/v1/projects",
                            "source_ranges.#": "1",
                            "source_ranges.1080289494": "0.0.0.0/0"
                        }
                    }
                },
                "google_compute_firewall.db-firewall-int": {
                    "type": "google_compute_firewall",
                    "depends_on": [
                        "google_compute_network.db-network",
                        "google_compute_network.db-network"
                    ],
                    "primary": {
                        "id": "db-firewall-int",
                        "attributes": {
                            "allow.#": "2",
                            "allow.1249999313.ports.#": "1",
                            "allow.1249999313.ports.1101440173": "1-65535",
                            "allow.1249999313.protocol": "tcp",
                            "allow.4162789437.ports.#": "1",
                            "allow.4162789437.ports.1101440173": "1-65535",
                            "allow.4162789437.protocol": "udp",
                            "id": "db-firewall-int",
                            "name": "db-firewall-int",
                            "network": "dbcluster",
                            "self_link": "https://www.googleapis.com/compute/v1/projects",
                            "source_ranges.#": "1",
                            "source_ranges.179966490": "10.0.0.0/16"
                        }
                    }
                },
                "google_compute_instance.dbcluster-nodes": {
                    "type": "google_compute_instance",
                    "depends_on": [
                        "google_compute_disk.dbcluster-lvm",
                        "google_compute_network.db-network"
                    ],
                    "primary": {
                        "id": "db-01",
                        "attributes": {
                            "can_ip_forward": "false",
                            "description": "dbcluster node #01",
                            "disk.#": "2",
                            "disk.0.auto_delete": "true",
                            "disk.0.device_name": "",
                            "disk.0.disk": "",
                            "disk.0.image": "centos-7-v20150526",
                            "disk.0.scratch": "false",
                            "disk.0.size": "20",
                            "disk.0.type": "",
                            "disk.1.auto_delete": "false",
                            "disk.1.device_name": "lvm",
                            "disk.1.disk": "db-lvm-01",
                            "disk.1.image": "",
                            "disk.1.scratch": "false",
                            "disk.1.size": "0",
                            "disk.1.type": "",
                            "id": "db-01",
                            "machine_type": "n1-standard-1",
                            "metadata.#": "4",
                            "metadata.dc": "gce-dc",
                            "metadata.role": "dbhost",
                            "metadata.sshKeys": "...",
                            "metadata.ssh_user": "centos",
                            "metadata_fingerprint": "...",
                            "name": "db-01",
                            "network.#": "0",
                            "network_interface.#": "1",
                            "network_interface.0.access_config.#": "1",
                            "network_interface.0.access_config.0.nat_ip": "1.1.1.1",
                            "network_interface.0.address": "10.0.0.2",
                            "network_interface.0.name": "nic0",
                            "network_interface.0.network": "dbcluster",
                            "self_link": "https://www.googleapis.com/compute/v1/projects",
                            "service_account.#": "0",
                            "tags.#": "2",
                            "tags.232903978": "dbcluster",
                            "tags.3824466984": "db",
                            "tags_fingerprint": "...",
                            "zone": "europe-west1-b"
                        },
                        "meta": {
                            "schema_version": "2"
                        }
                    }
                },
                "google_compute_network.db-network": {
                    "type": "google_compute_network",
                    "primary": {
                        "id": "dbcluster",
                        "attributes": {
                            "gateway_ipv4": "10.0.0.1",
                            "id": "dbcluster",
                            "ipv4_range": "10.0.0.0/16",
                            "name": "dbcluster",
                            "self_link": "https://www.googleapis.com/compute/v1/projects"
                        }
                    }
                }
            }
        }
    ]
}

```

Example:
```
$ ./terraform-inventory --list
{"dbcluster-nodes":["1.1.1.1"]}
```