### PR TITLE
Add ENV TERRAFORM_INVENTORY_KEYNAME to specify which IP to return

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -134,7 +134,7 @@ func (r Resource) NameWithCounter() string {
 
 // Address returns the IP address of this resource.
 func (r Resource) Address() string {
-	if keyName := os.Getenv("TERRAFORM_INVENTORY_KEYNAME"); keyName != "" {
+	if keyName := os.Getenv("TF_KEY_NAME"); keyName != "" {
 		if ip := r.State.Primary.Attributes[keyName]; ip != "" {
 			return ip
 		}

--- a/resource.go
+++ b/resource.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -133,9 +134,15 @@ func (r Resource) NameWithCounter() string {
 
 // Address returns the IP address of this resource.
 func (r Resource) Address() string {
-	for _, key := range keyNames {
-		if ip := r.State.Primary.Attributes[key]; ip != "" {
+	if keyName := os.Getenv("TERRAFORM_INVENTORY_KEYNAME"); keyName != "" {
+		if ip := r.State.Primary.Attributes[keyName]; ip != "" {
 			return ip
+		}
+	} else {
+		for _, key := range keyNames {
+			if ip := r.State.Primary.Attributes[key]; ip != "" {
+				return ip
+			}
 		}
 	}
 


### PR DESCRIPTION
I am not sure that this PR is useful. But I need it. :-) 
For example, I want to use the terraform-inventory in a VPC.

$export TERRAFORM_INVENTORY_KEYNAME=private_ip
(go:terraform-inventory) anarch@booker ~/go/terraform-inventory/src/anarcher/terraform-inventory (master) 
$./terraform-inventory --list
{ "instance" : ["10.90.0.2"],"name_instance" : ["10.90.0.35"] }

Anyway,  I like the terraform-inventory. It's a good idea and very useful for me! :-)

Thanks,
