### PR TITLE
Added the inventory option to produce an output similar to Ansible host file

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-func cmdList(stdout io.Writer, stderr io.Writer, s *state) int {
+func gatherResources(s *state) map[string][]string {
 	groups := make(map[string][]string, 0)
 	for _, res := range s.resources() {
 		for _, grp := range res.Groups() {
@@ -19,8 +19,40 @@ func cmdList(stdout io.Writer, stderr io.Writer, s *state) int {
 			groups[grp] = append(groups[grp], res.Address())
 		}
 	}
+    return groups
+}
 
-	return output(stdout, stderr, groups)
+func cmdList(stdout io.Writer, stderr io.Writer, s *state) int {
+	return output(stdout, stderr, gatherResources(s))
+}
+
+func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
+    groups := gatherResources(s)
+    for group, res := range groups {
+
+        _, err := io.WriteString(stdout, "["+group+"]\n")
+        if err != nil {
+		    fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
+            return 1;
+        }
+
+        for _, ress := range res {
+
+            _, err := io.WriteString(stdout, ress + "\n")
+            if err != nil {
+		        fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
+                return 1;
+            }
+        }
+
+        _, err = io.WriteString(stdout, "\n")
+        if err != nil {
+		    fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 func cmdHost(stdout io.Writer, stderr io.Writer, s *state, hostname string) int {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 var version = flag.Bool("version", false, "print version information and exit")
 var list = flag.Bool("list", false, "list mode")
 var host = flag.String("host", "", "host mode")
+var inventory = flag.Bool("inventory", false, "inventory mode")
 
 func main() {
 	flag.Parse()
@@ -44,7 +45,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !*list && *host == "" {
+	if !*list && *host == "" && !*inventory {
 		fmt.Fprint(os.Stderr, "Either --host or --list must be specified")
 		os.Exit(1)
 	}
@@ -71,6 +72,9 @@ func main() {
 
 	if *list {
 		os.Exit(cmdList(os.Stdout, os.Stderr, &s))
+
+	} else if *inventory {
+		os.Exit(cmdInventory(os.Stdout, os.Stderr, &s))
 
 	} else if *host != "" {
 		os.Exit(cmdHost(os.Stdout, os.Stderr, &s, *host))


### PR DESCRIPTION
I introduced the --inventory option which changes the output from the classic json format from --list to an output similar to Ansible host file.
The following configuration:

    resource "digitalocean_droplet" "gamma" {
      image = "centos-7-0-x64"
      name = "terraform-inventory-1"
      region = "nyc1"
      size = "512mb"
      ssh_keys = [862272]
    }

    resource "digitalocean_droplet" "zeta" {
      image = "centos-7-0-x64"
      name = "terraform-inventory-1"
      region = "nyc1"
      size = "512mb"
      ssh_keys = [862272]
    }

Would generate the following host file:

    [gamma]
    192.81.216.231

    [gamma.0]
    192.81.216.231

    [type_digitalocean_droplet]
    192.81.216.231
    198.211.97.15

    [zeta]
    198.211.97.15

    [zeta.0]
    198.211.97.15


This output can be fed to Ansible to provision remotes servers.