### PR TITLE
Improve Homebrew installation support

### DIFF
--- a/HomebrewFormula/terraform-inventory.rb
+++ b/HomebrewFormula/terraform-inventory.rb
@@ -4,7 +4,7 @@ class TerraformInventory < Formula
 
   # Update these when a new version is released
   url "https://github.com/adammck/terraform-inventory/archive/v0.6.1.tar.gz"
-  sha1 "4017f58718252a273713bbb6732d9028c5007930"
+  sha256 "9cdcbc5ce4247b72bb72923d01246f51252a88908d760d766daeac51dd8feed9"
 
   depends_on "go" => :build
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ with Terraform, then (re-)provision them with Ansible. Currently, only **AWS**,
 
 On OSX, install it with Homebrew:
 
-	brew install https://raw.github.com/adammck/terraform-inventory/master/homebrew/terraform-inventory.rb
+	brew tap adammck/terraform-inventory https://github.com/adammck/terraform-inventory
+	brew install terraform-inventory
 
 This is only a tiny tool, so it's not in the main Homebrew repo. Feel free to
 add it, if you think that would be useful.
 
 Alternatively, you can download a [release](https://github.com/adammck/terraform-inventory/releases) suitable
-to your platform and unzip it. Make sure the `terraform-inventory` binary is executable and you're ready to go.
+to your platform and unzip it. Make sure the `terraform-inventory` binary is executable, and you're ready to go.
 
 
 ## Usage
@@ -134,5 +135,5 @@ was generously sponsored by [Transloadit](https://transloadit.com).
 
 MIT.
 
-[ansible]: http://www.ansible.com
-[tf]:      http://www.terraform.io
+[ansible]: https://www.ansible.com
+[tf]:      https://www.terraform.io


### PR DESCRIPTION
Make this repository work with `brew tap` and use SHA-256 for checksum,
as SHA-1 support is deprecated.