### PR TITLE
New `outputs` format in tfstate

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -35,7 +35,16 @@ func (s *state) outputs() []*Output {
 
 	for _, m := range s.Modules {
 		for k, v := range m.Outputs {
-			o, _ := NewOutput(k, v.Value)
+			var o *Output;
+			switch v := v.(type) {
+			case map[string]interface{}:
+				o, _ = NewOutput(k, v["value"].(string))
+			case string:
+				o, _ = NewOutput(k, v)
+			default:
+				o, _ = NewOutput(k, "<error>")
+			}
+
 			inst = append(inst, o)
 		}
 	}
@@ -66,15 +75,9 @@ func (s *state) resources() []*Resource {
 	return inst
 }
 
-type outputState struct {
-	Value     string `json:"value"`
-	Sensitive bool   `json:"sensitive"`
-	Type      string `json:"type"`
-}
-
 type moduleState struct {
 	ResourceStates map[string]resourceState `json:"resources"`
-	Outputs        map[string]outputState   `json:"outputs"`
+	Outputs        map[string]interface{}   `json:"outputs"`
 }
 
 // resourceKeys returns a sorted slice of the key names of the resources in this

--- a/parser.go
+++ b/parser.go
@@ -35,7 +35,7 @@ func (s *state) outputs() []*Output {
 
 	for _, m := range s.Modules {
 		for k, v := range m.Outputs {
-			o, _ := NewOutput(k, v)
+			o, _ := NewOutput(k, v.Value)
 			inst = append(inst, o)
 		}
 	}
@@ -66,9 +66,15 @@ func (s *state) resources() []*Resource {
 	return inst
 }
 
+type outputState struct {
+	Value     string `json:"value"`
+	Sensitive bool   `json:"sensitive"`
+	Type      string `json:"type"`
+}
+
 type moduleState struct {
 	ResourceStates map[string]resourceState `json:"resources"`
-	Outputs        map[string]string        `json:"outputs"`
+	Outputs        map[string]outputState   `json:"outputs"`
 }
 
 // resourceKeys returns a sorted slice of the key names of the resources in this

--- a/parser_test.go
+++ b/parser_test.go
@@ -19,6 +19,7 @@ const exampleStateFile = `
 				"root"
 			],
 			"outputs": {
+				    "olddatacenter": "<0.7_format",
 				    "datacenter": {
 					"sensitive": false,
 					"type": "string",
@@ -128,7 +129,7 @@ const exampleStateFile = `
 
 const expectedListOutput = `
 {
-	"all":	 {"datacenter": "mydc"},
+	"all":	 {"datacenter": "mydc", "olddatacenter": "<0.7_format"},
 	"one":   ["10.0.0.1", "10.0.1.1"],
 	"two":   ["50.0.0.1"],
 	"three": ["192.168.0.3"],

--- a/parser_test.go
+++ b/parser_test.go
@@ -18,9 +18,13 @@ const exampleStateFile = `
 			"path": [
 				"root"
 			],
-      "outputs": {
-          "datacenter": "mydc"
-      },
+			"outputs": {
+				    "datacenter": {
+					"sensitive": false,
+					"type": "string",
+					"value": "mydc"
+				    }
+			},
 			"resources": {
 				"aws_instance.one.0": {
 					"type": "aws_instance",


### PR DESCRIPTION
I'm not sure if this is a 0.7.0 change, but the format of the `outputs` object in terraform state file change to the following:

    "outputs": {
        "datacenter": {
            "sensitive": false,
            "type": "string",
            "value": "mydc"
        }
    }