### PR TITLE
allow for non-string outputs

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -21,9 +21,9 @@ func gatherResources(s *state) map[string]interface{} {
 	}
 
 	if len(s.outputs()) > 0 {
-		groups["all"] = make(map[string]string, 0)
+		groups["all"] = make(map[string]interface{}, 0)
 		for _, out := range s.outputs() {
-			groups["all"].(map[string]string)[out.keyName] = out.value
+			groups["all"].(map[string]interface{})[out.keyName] = out.value
 		}
 	}
 	return groups

--- a/output.go
+++ b/output.go
@@ -8,10 +8,10 @@ type Output struct {
 
 	// The keyName and value of the output
 	keyName string
-	value   string
+	value   interface{}
 }
 
-func NewOutput(keyName string, value string) (*Output, error) {
+func NewOutput(keyName string, value interface{}) (*Output, error) {
 
 	// TODO: Warn instead of silently ignore error?
 	if len(keyName) == 0 {

--- a/parser.go
+++ b/parser.go
@@ -35,10 +35,10 @@ func (s *state) outputs() []*Output {
 
 	for _, m := range s.Modules {
 		for k, v := range m.Outputs {
-			var o *Output;
+			var o *Output
 			switch v := v.(type) {
 			case map[string]interface{}:
-				o, _ = NewOutput(k, v["value"].(string))
+				o, _ = NewOutput(k, v["value"])
 			case string:
 				o, _ = NewOutput(k, v)
 			default:

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,7 +24,17 @@ const exampleStateFile = `
 					"sensitive": false,
 					"type": "string",
 					"value": "mydc"
-				    }
+				    },
+					"ids": {
+						"type": "list",
+						"value": [1, 2, 3, 4]
+					},
+					"map": {
+						"type": "map",
+						"value": {
+							"key": "value"
+						}
+					}
 			},
 			"resources": {
 				"aws_instance.one.0": {
@@ -129,7 +139,7 @@ const exampleStateFile = `
 
 const expectedListOutput = `
 {
-	"all":	 {"datacenter": "mydc", "olddatacenter": "<0.7_format"},
+	"all":	 {"datacenter": "mydc", "olddatacenter": "<0.7_format", "ids": [1, 2, 3, 4], "map": {"key": "value"}},
 	"one":   ["10.0.0.1", "10.0.1.1"],
 	"two":   ["50.0.0.1"],
 	"three": ["192.168.0.3"],


### PR DESCRIPTION
not sure if this is new in 0.7, but non-string outputs are allowed.  Without this fix, I get 

```
panic: interface conversion: interface is []interface {}, not string

goroutine 1 [running]:
panic(0x1020e0, 0xc420498e00)
        /Users/isao/.gimme/versions/go1.7.darwin.amd64/src/runtime/panic.go:500 +0x1a1
main.(*state).outputs(0xc4200722c0, 0xc420357bc0, 0xc4202cdd00, 0xc4202cdd50)
        /Users/isao/dev/src/github.com/adammck/terraform-inventory/parser.go:41 +0x3b0
main.gatherResources(0xc4200722c0, 0xc4a44)
        /Users/isao/dev/src/github.com/adammck/terraform-inventory/cli.go:23 +0x3a3
main.cmdList(0x19f4c0, 0xc420098008, 0x19f4c0, 0xc420098010, 0xc4200722c0, 0x0)
        /Users/isao/dev/src/github.com/adammck/terraform-inventory/cli.go:33 +0x2b
main.main()
        /Users/isao/dev/src/github.com/adammck/terraform-inventory/main.go:63 +0x4e4
```