### PR TITLE
Create all group as per Ansible inventory script conventions

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -45,28 +45,41 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 	groups := gatherResources(s)
 	for group, res := range groups {
 
-		_, err := io.WriteString(stdout, "["+group+"]\n")
-		if err != nil {
-			fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
-			return 1
+		switch grp := res.(type) {
+			case []string:
+				writeLn("["+group+"]", stdout, stderr)
+			    for _, item := range grp {
+					writeLn(item, stdout, stderr)
+				}
+
+			case *allGroup:
+				writeLn("["+group+"]", stdout, stderr)
+			    for _, item := range grp.Hosts {
+			    	writeLn(item, stdout, stderr)
+				}
+				writeLn("", stdout, stderr)
+				writeLn("["+group+":vars]", stdout, stderr)
+			    for key, item := range grp.Vars {
+			    	writeLn(key+"="+item, stdout, stderr)
+				}
 		}
 
-		for _, ress := range res.([]string) {
-
-			_, err := io.WriteString(stdout, ress+"\n")
-			if err != nil {
-				fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
-				return 1
-			}
-		}
-
-		_, err = io.WriteString(stdout, "\n")
-		if err != nil {
-			fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
-			return 1
-		}
+		writeLn("", stdout, stderr)
 	}
 
+	return 0
+}
+
+func writeLn(str string, stdout io.Writer, stderr io.Writer) {
+	_, err := io.WriteString(stdout, str + "\n")
+	checkErr(err, stderr)
+}
+
+func checkErr(err error, stderr io.Writer) int {
+	if err != nil {
+		fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
+		return 1
+	}
 	return 0
 }
 

--- a/cli.go
+++ b/cli.go
@@ -6,8 +6,16 @@ import (
 	"io"
 )
 
+type allGroup struct {
+	Hosts []string          `json:"hosts"`
+	Vars  map[string]string `json:"vars"`
+}
+
 func gatherResources(s *state) map[string]interface{} {
 	groups := make(map[string]interface{}, 0)
+	all_group := allGroup{Vars: make(map[string]string)}
+	groups["all"] = &all_group
+
 	for _, res := range s.resources() {
 		for _, grp := range res.Groups() {
 
@@ -17,13 +25,13 @@ func gatherResources(s *state) map[string]interface{} {
 			}
 
 			groups[grp] = append(groups[grp].([]string), res.Address())
+			all_group.Hosts = append(all_group.Hosts, res.Address())
 		}
 	}
 
 	if len(s.outputs()) > 0 {
-		groups["all"] = make(map[string]interface{}, 0)
 		for _, out := range s.outputs() {
-			groups["all"].(map[string]interface{})[out.keyName] = out.value
+			all_group.Vars[out.keyName] = out.value.(string)
 		}
 	}
 	return groups

--- a/cli.go
+++ b/cli.go
@@ -8,8 +8,8 @@ import (
 )
 
 type allGroup struct {
-	Hosts []string          `json:"hosts"`
-	Vars  map[string]string `json:"vars"`
+	Hosts []string               `json:"hosts"`
+	Vars  map[string]interface{} `json:"vars"`
 }
 
 func appendUniq(strs []string, item string) []string {
@@ -27,7 +27,7 @@ func appendUniq(strs []string, item string) []string {
 
 func gatherResources(s *state) map[string]interface{} {
 	groups := make(map[string]interface{}, 0)
-	all_group := allGroup{Vars: make(map[string]string)}
+	all_group := allGroup{Vars: make(map[string]interface{})}
 	groups["all"] = &all_group
 
 	for _, res := range s.resources() {
@@ -45,7 +45,7 @@ func gatherResources(s *state) map[string]interface{} {
 
 	if len(s.outputs()) > 0 {
 		for _, out := range s.outputs() {
-			all_group.Vars[out.keyName] = out.value.(string)
+			all_group.Vars[out.keyName] = out.value
 		}
 	}
 	return groups
@@ -74,7 +74,7 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 			writeLn("", stdout, stderr)
 			writeLn("["+group+":vars]", stdout, stderr)
 			for key, item := range grp.Vars {
-				writeLn(key+"="+item, stdout, stderr)
+				writeLn(key+"="+item.(string), stdout, stderr)
 			}
 		}
 

--- a/cli.go
+++ b/cli.go
@@ -4,11 +4,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 )
 
 type allGroup struct {
 	Hosts []string          `json:"hosts"`
 	Vars  map[string]string `json:"vars"`
+}
+
+func appendUniq (strs []string, item string) []string {	
+	if len(strs) == 0 {
+		strs = append(strs, item)
+		return strs
+	}
+	sort.Strings(strs)
+	i := sort.SearchStrings(strs, item)
+	if i < len(strs) && strs[i] != item {
+		strs = append(strs, item)	
+	}
+	return strs
 }
 
 func gatherResources(s *state) map[string]interface{} {
@@ -25,7 +39,7 @@ func gatherResources(s *state) map[string]interface{} {
 			}
 
 			groups[grp] = append(groups[grp].([]string), res.Address())
-			all_group.Hosts = append(all_group.Hosts, res.Address())
+			all_group.Hosts = appendUniq(all_group.Hosts, res.Address())
 		}
 	}
 

--- a/cli.go
+++ b/cli.go
@@ -12,7 +12,7 @@ type allGroup struct {
 	Vars  map[string]string `json:"vars"`
 }
 
-func appendUniq (strs []string, item string) []string {	
+func appendUniq(strs []string, item string) []string {
 	if len(strs) == 0 {
 		strs = append(strs, item)
 		return strs
@@ -20,7 +20,7 @@ func appendUniq (strs []string, item string) []string {
 	sort.Strings(strs)
 	i := sort.SearchStrings(strs, item)
 	if i < len(strs) && strs[i] != item {
-		strs = append(strs, item)	
+		strs = append(strs, item)
 	}
 	return strs
 }
@@ -60,22 +60,22 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 	for group, res := range groups {
 
 		switch grp := res.(type) {
-			case []string:
-				writeLn("["+group+"]", stdout, stderr)
-			    for _, item := range grp {
-					writeLn(item, stdout, stderr)
-				}
+		case []string:
+			writeLn("["+group+"]", stdout, stderr)
+			for _, item := range grp {
+				writeLn(item, stdout, stderr)
+			}
 
-			case *allGroup:
-				writeLn("["+group+"]", stdout, stderr)
-			    for _, item := range grp.Hosts {
-			    	writeLn(item, stdout, stderr)
-				}
-				writeLn("", stdout, stderr)
-				writeLn("["+group+":vars]", stdout, stderr)
-			    for key, item := range grp.Vars {
-			    	writeLn(key+"="+item, stdout, stderr)
-				}
+		case *allGroup:
+			writeLn("["+group+"]", stdout, stderr)
+			for _, item := range grp.Hosts {
+				writeLn(item, stdout, stderr)
+			}
+			writeLn("", stdout, stderr)
+			writeLn("["+group+":vars]", stdout, stderr)
+			for key, item := range grp.Vars {
+				writeLn(key+"="+item, stdout, stderr)
+			}
 		}
 
 		writeLn("", stdout, stderr)
@@ -85,7 +85,7 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 }
 
 func writeLn(str string, stdout io.Writer, stderr io.Writer) {
-	_, err := io.WriteString(stdout, str + "\n")
+	_, err := io.WriteString(stdout, str+"\n")
 	checkErr(err, stderr)
 }
 

--- a/cli.go
+++ b/cli.go
@@ -91,7 +91,7 @@ func writeLn(str string, stdout io.Writer, stderr io.Writer) {
 
 func checkErr(err error, stderr io.Writer) int {
 	if err != nil {
-		fmt.Fprintf(stderr, "Error writing Invetory: %s\n", err)
+		fmt.Fprintf(stderr, "Error writing inventory: %s\n", err)
 		return 1
 	}
 	return 0

--- a/cli.go
+++ b/cli.go
@@ -19,7 +19,7 @@ func appendUniq(strs []string, item string) []string {
 	}
 	sort.Strings(strs)
 	i := sort.SearchStrings(strs, item)
-	if i < len(strs) && strs[i] != item {
+	if i == len(strs) || (i < len(strs) && strs[i] != item) {
 		strs = append(strs, item)
 	}
 	return strs
@@ -38,7 +38,7 @@ func gatherResources(s *state) map[string]interface{} {
 				groups[grp] = []string{}
 			}
 
-			groups[grp] = append(groups[grp].([]string), res.Address())
+			groups[grp] = appendUniq(groups[grp].([]string), res.Address())
 			all_group.Hosts = appendUniq(all_group.Hosts, res.Address())
 		}
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -139,7 +139,15 @@ const exampleStateFile = `
 
 const expectedListOutput = `
 {
-	"all":	 {"datacenter": "mydc", "olddatacenter": "<0.7_format", "ids": [1, 2, 3, 4], "map": {"key": "value"}},
+	"all":	 {
+		"hosts": ["10.0.0.1"], 
+		"vars": {
+			"datacenter": "mydc", 
+			"olddatacenter": "<0.7_format", 
+			"ids": [1, 2, 3, 4], 
+			"map": {"key": "value"}
+		}
+	},
 	"one":   ["10.0.0.1", "10.0.1.1"],
 	"two":   ["50.0.0.1"],
 	"three": ["192.168.0.3"],

--- a/parser_test.go
+++ b/parser_test.go
@@ -49,6 +49,18 @@ const exampleStateFile = `
 						}
 					}
 				},
+				"aws_instance.dup.0": {
+					"type": "aws_instance",
+					"primary": {
+						"id": "i-aaaaaaaa",
+						"attributes": {
+							"id": "i-aaaaaaaa",
+							"private_ip": "10.0.0.1",
+							"tags.#": "1",
+							"tags.Role": "Web"
+						}
+					}
+				},
 				"aws_instance.one.1": {
 					"type": "aws_instance",
 					"primary": {
@@ -140,7 +152,15 @@ const exampleStateFile = `
 const expectedListOutput = `
 {
 	"all":	 {
-		"hosts": ["10.0.0.1"], 
+		"hosts": [
+			"10.0.0.1", 
+			"10.0.1.1",
+			"10.120.0.226",
+			"10.2.1.5", 
+			"10.20.30.40",
+			"192.168.0.3",
+			"50.0.0.1"
+		], 
 		"vars": {
 			"datacenter": "mydc", 
 			"olddatacenter": "<0.7_format", 
@@ -149,6 +169,7 @@ const expectedListOutput = `
 		}
 	},
 	"one":   ["10.0.0.1", "10.0.1.1"],
+	"dup":   ["10.0.0.1"],
 	"two":   ["50.0.0.1"],
 	"three": ["192.168.0.3"],
 	"four":  ["10.2.1.5"],
@@ -156,6 +177,7 @@ const expectedListOutput = `
 	"six":   ["10.120.0.226"],
 
 	"one.0":   ["10.0.0.1"],
+	"dup.0":   ["10.0.0.1"],
 	"one.1":   ["10.0.1.1"],
 	"two.0":   ["50.0.0.1"],
 	"three.0": ["192.168.0.3"],


### PR DESCRIPTION
I first noticed that I was unable to run `terraform-inventory --list` without first exporting `TF_STATE=.terraform/terraform.tfstate` and as per the README it appears as though having to export TF_STATE was optional. Second, I noticed that when running `ansible-playbook` with the `--list-hosts` flag `ansible-playbook` would say there were no hosts found. When I removed `--list-hosts` it detected the host that the playbook should run against.

I then ran `git bisect` to track down the problem. And I was led to this commit https://github.com/adammck/terraform-inventory/commit/6ead28eee6fce717940d217b7d7705ea4104845f. I noticed that in cli.go this change added an "all" group to the Ansible inventory, so I went to check the Ansible docs regarding the format expected from a script.

http://docs.ansible.com/ansible/developing_inventory.html#script-conventions
The JSON generated from the master branch creates an "all" group containing a mapping of variable keys and values. According to the Ansible docs that mapping should be under the "vars" key of the "all" group.

After making these changes it has fixed both of the problems I was encountering.