### PR TITLE
Stop creating groups for tfstate attribute counts

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -44,7 +44,7 @@ const exampleStateFile = `
 						"attributes": {
 							"id": "i-aaaaaaaa",
 							"private_ip": "10.0.0.1",
-							"tags.#": "1",
+							"tags.%": "1",
 							"tags.Role": "Web"
 						}
 					}

--- a/resource.go
+++ b/resource.go
@@ -110,7 +110,10 @@ func (r Resource) Tags() map[string]string {
 	case "aws_instance":
 		for k, v := range r.Attributes() {
 			parts := strings.SplitN(k, ".", 2)
-			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "#" {
+			// At some point Terraform changed the key for counts of attributes to end with ".%"
+			// instead of ".#". Both need to be considered as Terraform still supports state
+			// files using the old format.
+			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "#" && parts[1] != "%" {
 				kk := strings.ToLower(parts[1])
 				vv := strings.ToLower(v)
 				t[kk] = vv


### PR DESCRIPTION
`terraform-inventory` currently creates groups like the following...

`{"%_5":["10.95.12.224"],"%_6":["53.81.162.94"], ...`

This ensures these groups do not get created.
