### PR TITLE
add support for remote state in version 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,25 @@ Can be provisioned separately with:
 ## More Usage
 
 Ansible doesn't seem to support calling a dynamic inventory script with params,
-so if you need to specify the location of your state file, set the `TF_STATE`
+so if you need to specify the location of your state file or terraform directory, set the `TF_STATE`
 environment variable before running `ansible-playbook`, like:
 
+
 	TF_STATE=deploy/terraform.tfstate ansible-playbook --inventory-file=/path/to/terraform-inventory deploy/playbook.yml
+
+	or
+
+	TF_STATE=../terraform ansible-playbook --inventory-file=/path/to/terraform-inventory deploy/playbook.yml
+
+If `TF_STATE` is a file, it parses the file as json, if `TF_STATE` is a directory, it runs `terraform state pull` inside the directory, which is supports both local and remote terraform state.
+
+It looks for state config in this order
+
+- `TF_STATE`: environment variable of where to find either a statefile or a terraform project
+- `TI_TFSTATE`: another environment variable similar to TF_STATE
+- `terraform.tfstate`: it looks in the state file in the current directory.
+- `.terraform/terraform.tfstate`: it looks for state file in the other default known location
+- `.`: lastly it assumes you are at the root of a terraform project.
 
 Alternately, if you need to do something fancier (like downloading your state
 file from S3 before running), you might wrap this tool with a shell script, and

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ It looks for state config in this order
 - `TF_STATE`: environment variable of where to find either a statefile or a terraform project
 - `TI_TFSTATE`: another environment variable similar to TF_STATE
 - `terraform.tfstate`: it looks in the state file in the current directory.
-- `.terraform/terraform.tfstate`: it looks for state file in the other default known location
 - `.`: lastly it assumes you are at the root of a terraform project.
 
 Alternately, if you need to do something fancier (like downloading your state

--- a/input.go
+++ b/input.go
@@ -31,5 +31,5 @@ func GetInputPath(fs vfs.Filesystem, env venv.Env) string {
 		return fn
 	}
 
-	return ""
+	return "."
 }

--- a/input.go
+++ b/input.go
@@ -25,11 +25,5 @@ func GetInputPath(fs vfs.Filesystem, env venv.Env) string {
 		return fn
 	}
 
-	fn = ".terraform/terraform.tfstate"
-	_, err = fs.Stat(fn)
-	if err == nil {
-		return fn
-	}
-
 	return "."
 }

--- a/input_test.go
+++ b/input_test.go
@@ -17,7 +17,7 @@ func TestGetInputPath(t *testing.T) {
 	assert.Equal(t, "aaa", GetInputPath(memfs.Create(), envWith(map[string]string{"TF_STATE": "aaa"})))
 	assert.Equal(t, "bbb", GetInputPath(memfs.Create(), envWith(map[string]string{"TI_TFSTATE": "bbb"})))
 	assert.Equal(t, "terraform.tfstate", GetInputPath(fsWithFiles([]string{"terraform.tfstate"}), venv.Mock()))
-	assert.Equal(t, ".terraform/terraform.tfstate", GetInputPath(fsWithFiles([]string{".terraform/terraform.tfstate"}), venv.Mock()))
+	assert.Equal(t, ".", GetInputPath(fsWithFiles([]string{".terraform/terraform.tfstate"}), venv.Mock()))
 	assert.Equal(t, "terraform", GetInputPath(fsWithDirs([]string{"terraform"}), envWith(map[string]string{"TF_STATE": "terraform"})))
 }
 

--- a/input_test.go
+++ b/input_test.go
@@ -13,11 +13,12 @@ import (
 )
 
 func TestGetInputPath(t *testing.T) {
-	assert.Equal(t, "", GetInputPath(memfs.Create(), venv.Mock()))
+	assert.Equal(t, ".", GetInputPath(memfs.Create(), venv.Mock()))
 	assert.Equal(t, "aaa", GetInputPath(memfs.Create(), envWith(map[string]string{"TF_STATE": "aaa"})))
 	assert.Equal(t, "bbb", GetInputPath(memfs.Create(), envWith(map[string]string{"TI_TFSTATE": "bbb"})))
 	assert.Equal(t, "terraform.tfstate", GetInputPath(fsWithFiles([]string{"terraform.tfstate"}), venv.Mock()))
 	assert.Equal(t, ".terraform/terraform.tfstate", GetInputPath(fsWithFiles([]string{".terraform/terraform.tfstate"}), venv.Mock()))
+	assert.Equal(t, "terraform", GetInputPath(fsWithDirs([]string{"terraform"}), envWith(map[string]string{"TF_STATE": "terraform"})))
 }
 
 func envWith(env map[string]string) venv.Env {
@@ -45,6 +46,21 @@ func fsWithFiles(filenames []string) vfs.Filesystem {
 		}
 
 		err = touchFile(fs, fn)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return fs
+}
+
+func fsWithDirs(dirs []string) vfs.Filesystem {
+	fs := memfs.Create()
+
+	var err error
+
+	for _, fp := range dirs {
+		err = vfs.MkdirAll(fs, fp, 0700)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This PR adds support for
- TF_STATE, can be a path to a state file or a path to a terraform root directory
- If it is a directory it runs `terraform state pull` which manages both local and remote state as documented [here](https://www.terraform.io/docs/commands/state/pull.html).

I had a look at [#PR59](https://github.com/adammck/terraform-inventory/pull/59) but it I did not like the fact that it only support s3 and talked directly to it 