### PR TITLE
Add support for extracting tags (metadata) from OpenStack instances.

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -115,6 +115,15 @@ func (r Resource) Tags() map[string]string {
 	t := map[string]string{}
 
 	switch r.resourceType {
+	case "openstack_compute_instance_v2":
+		for k, v := range r.Attributes() {
+			parts := strings.SplitN(k, ".", 2)
+			if len(parts) == 2 && parts[0] == "metadata" && parts[1] != "#" {
+				kk := strings.ToLower(parts[1])
+				vv := strings.ToLower(v)
+				t[kk] = vv
+			}
+		}
 	case "aws_instance":
 		for k, v := range r.Attributes() {
 			parts := strings.SplitN(k, ".", 2)


### PR DESCRIPTION
Adds support for extracting tags (metadata) from OpenStack instances, in a similar fashion to AWS and Google Compute Engine. Tested on my local OpenStack cluster.