### PR TITLE
Fix non-string vars in --inventory output

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -57,9 +57,14 @@ func cmdList(stdout io.Writer, stderr io.Writer, s *state) int {
 
 func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 	groups := gatherResources(s)
-	for group, res := range groups {
+	group_names := []string{}
+	for group, _ := range groups {
+		group_names = append(group_names, group)
+	}
+	sort.Strings(group_names)
+	for _, group := range group_names {
 
-		switch grp := res.(type) {
+		switch grp := groups[group].(type) {
 		case []string:
 			writeLn("["+group+"]", stdout, stderr)
 			for _, item := range grp {
@@ -73,9 +78,14 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 			}
 			writeLn("", stdout, stderr)
 			writeLn("["+group+":vars]", stdout, stderr)
-			for key, item := range grp.Vars {
-				jsonItem, _ := json.Marshal(item)
-				itemLn := fmt.Sprintf("'%s'", string(jsonItem))
+			vars := []string{}
+			for key, _ := range grp.Vars {
+				vars = append(vars, key)
+			}
+			sort.Strings(vars)
+			for _, key := range vars {
+				jsonItem, _ := json.Marshal(grp.Vars["key"])
+				itemLn := fmt.Sprintf("%s", string(jsonItem))
 				writeLn(key+"="+itemLn, stdout, stderr)
 			}
 		}

--- a/cli.go
+++ b/cli.go
@@ -74,7 +74,9 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 			writeLn("", stdout, stderr)
 			writeLn("["+group+":vars]", stdout, stderr)
 			for key, item := range grp.Vars {
-				writeLn(key+"="+item.(string), stdout, stderr)
+				jsonItem, _ := json.Marshal(item)
+				itemLn := fmt.Sprintf("'%s'", string(jsonItem))
+				writeLn(key+"="+itemLn, stdout, stderr)
 			}
 		}
 

--- a/cli.go
+++ b/cli.go
@@ -84,7 +84,7 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 			}
 			sort.Strings(vars)
 			for _, key := range vars {
-				jsonItem, _ := json.Marshal(grp.Vars["key"])
+				jsonItem, _ := json.Marshal(grp.Vars[key])
 				itemLn := fmt.Sprintf("%s", string(jsonItem))
 				writeLn(key+"="+itemLn, stdout, stderr)
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -280,6 +280,134 @@ const expectedListOutput = `
 }
 `
 
+const expectedInventoryOutput = `[all]
+10.0.0.1
+10.0.0.7
+10.0.0.8
+10.0.0.9
+10.0.1.1
+10.120.0.226
+10.2.1.5
+10.20.30.40
+192.168.0.3
+50.0.0.1
+
+[all:vars]
+datacenter='"mydc"'
+ids='[1,2,3,4]'
+map='{"key":"value"}'
+olddatacenter='"\u003c0.7_format"'
+
+[one.0]
+10.0.0.1
+
+[four.0]
+10.2.1.5
+
+[webserver]
+192.168.0.3
+
+[type_vsphere_virtual_machine]
+10.20.30.40
+
+[seven.0]
+10.0.0.7
+
+[type_softlayer_virtual_guest]
+10.0.0.7
+
+[dup.0]
+10.0.0.1
+
+[type_digitalocean_droplet]
+192.168.0.3
+
+[nine.0]
+10.0.0.9
+
+[type_exoscale_compute]
+10.0.0.9
+
+[two.0]
+50.0.0.1
+
+[three]
+192.168.0.3
+
+[type_google_compute_instance]
+10.0.0.8
+
+[dup]
+10.0.0.1
+
+[one]
+10.0.0.1
+10.0.1.1
+
+[type_cloudstack_instance]
+10.2.1.5
+
+[role_rrrrrrrr]
+10.20.30.40
+
+[seven]
+10.0.0.7
+
+[five]
+10.20.30.40
+
+[role_web]
+10.0.0.1
+
+[three.0]
+192.168.0.3
+
+[eight.0]
+10.0.0.8
+
+[six.0]
+10.120.0.226
+
+[type_openstack_compute_instance_v2]
+10.120.0.226
+
+[status_superserver]
+10.120.0.226
+
+[type_aws_instance]
+10.0.0.1
+10.0.1.1
+50.0.0.1
+
+[two]
+50.0.0.1
+
+[nine]
+10.0.0.9
+
+[eight]
+10.0.0.8
+
+[six]
+10.120.0.226
+
+[five.0]
+10.20.30.40
+
+[one.1]
+10.0.1.1
+
+[four]
+10.2.1.5
+
+[staging]
+192.168.0.3
+
+[database]
+10.0.0.8
+
+`
+
 const expectedHostOneOutput = `
 {
 	"id":"i-aaaaaaaa",
@@ -337,4 +465,46 @@ func TestHostCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, exp, act)
+}
+
+//	I can't check is inventory are correct, so we need to do that chack with ansible
+//  PLAY [all] *******************************************
+//
+//  TASK [show ids] **************************************
+//  ok: [10.20.30.40] => {
+//  "msg": [
+//  1,
+//  2,
+//  3,
+//  4
+//  ]
+//  }
+//
+//  TASK [show map] ***************************************
+//  ok: [10.20.30.40] => {
+//  "msg": {
+//  "key": "value"
+//  }
+//  }
+func TestInventoryCommand(t *testing.T) {
+	var s state
+	r := strings.NewReader(exampleStateFile)
+	err := s.read(r)
+	assert.NoError(t, err)
+
+	// Run the command, capture the output
+	var stdout, stderr bytes.Buffer
+	exitCode := cmdInventory(&stdout, &stderr, &s)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "", stderr.String())
+
+	assert.Equal(t, helperCountCharInStrings(expectedInventoryOutput), helperCountCharInStrings(stdout.String()))
+}
+
+func helperCountCharInStrings(str string) map[rune]int {
+	result := map[rune]int{}
+	for _, i := range str {
+		result[i]++
+	}
+	return result
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -346,10 +346,10 @@ const expectedInventoryOutput = `[all]
 50.0.0.1
 
 [all:vars]
-datacenter=null
-ids=null
-map=null
-olddatacenter=null
+datacenter="mydc"
+ids=[1,2,3,4]
+map={"key":"value"}
+olddatacenter="\u003c0.7_format"
 
 [database]
 10.0.0.8

--- a/parser_test.go
+++ b/parser_test.go
@@ -334,6 +334,7 @@ const expectedListOutput = `
 
 const expectedInventoryOutput = `[all]
 10.0.0.1
+10.0.0.10
 10.0.0.7
 10.0.0.8
 10.0.0.9
@@ -396,6 +397,9 @@ olddatacenter=null
 [role_rrrrrrrr]
 10.20.30.40
 
+[role_test]
+10.0.0.10
+
 [role_web]
 10.0.0.1
 
@@ -416,6 +420,12 @@ olddatacenter=null
 
 [status_superserver]
 10.120.0.226
+
+[ten]
+10.0.0.10
+
+[ten.0]
+10.0.0.10
 
 [three]
 192.168.0.3
@@ -451,6 +461,9 @@ olddatacenter=null
 
 [type_softlayer_virtual_guest]
 10.0.0.7
+
+[type_triton_machine]
+10.0.0.10
 
 [type_vsphere_virtual_machine]
 10.20.30.40

--- a/parser_test.go
+++ b/parser_test.go
@@ -293,118 +293,118 @@ const expectedInventoryOutput = `[all]
 50.0.0.1
 
 [all:vars]
-datacenter='"mydc"'
-ids='[1,2,3,4]'
-map='{"key":"value"}'
-olddatacenter='"\u003c0.7_format"'
+datacenter=null
+ids=null
+map=null
+olddatacenter=null
 
-[one.0]
-10.0.0.1
-
-[four.0]
-10.2.1.5
-
-[webserver]
-192.168.0.3
-
-[type_vsphere_virtual_machine]
-10.20.30.40
-
-[seven.0]
-10.0.0.7
-
-[type_softlayer_virtual_guest]
-10.0.0.7
-
-[dup.0]
-10.0.0.1
-
-[type_digitalocean_droplet]
-192.168.0.3
-
-[nine.0]
-10.0.0.9
-
-[type_exoscale_compute]
-10.0.0.9
-
-[two.0]
-50.0.0.1
-
-[three]
-192.168.0.3
-
-[type_google_compute_instance]
+[database]
 10.0.0.8
 
 [dup]
 10.0.0.1
 
+[dup.0]
+10.0.0.1
+
+[eight]
+10.0.0.8
+
+[eight.0]
+10.0.0.8
+
+[five]
+10.20.30.40
+
+[five.0]
+10.20.30.40
+
+[four]
+10.2.1.5
+
+[four.0]
+10.2.1.5
+
+[nine]
+10.0.0.9
+
+[nine.0]
+10.0.0.9
+
 [one]
 10.0.0.1
 10.0.1.1
 
-[type_cloudstack_instance]
-10.2.1.5
+[one.0]
+10.0.0.1
+
+[one.1]
+10.0.1.1
 
 [role_rrrrrrrr]
-10.20.30.40
-
-[seven]
-10.0.0.7
-
-[five]
 10.20.30.40
 
 [role_web]
 10.0.0.1
 
-[three.0]
-192.168.0.3
+[seven]
+10.0.0.7
 
-[eight.0]
-10.0.0.8
+[seven.0]
+10.0.0.7
+
+[six]
+10.120.0.226
 
 [six.0]
 10.120.0.226
 
-[type_openstack_compute_instance_v2]
-10.120.0.226
+[staging]
+192.168.0.3
 
 [status_superserver]
 10.120.0.226
+
+[three]
+192.168.0.3
+
+[three.0]
+192.168.0.3
+
+[two]
+50.0.0.1
+
+[two.0]
+50.0.0.1
 
 [type_aws_instance]
 10.0.0.1
 10.0.1.1
 50.0.0.1
 
-[two]
-50.0.0.1
-
-[nine]
-10.0.0.9
-
-[eight]
-10.0.0.8
-
-[six]
-10.120.0.226
-
-[five.0]
-10.20.30.40
-
-[one.1]
-10.0.1.1
-
-[four]
+[type_cloudstack_instance]
 10.2.1.5
 
-[staging]
+[type_digitalocean_droplet]
 192.168.0.3
 
-[database]
+[type_exoscale_compute]
+10.0.0.9
+
+[type_google_compute_instance]
 10.0.0.8
+
+[type_openstack_compute_instance_v2]
+10.120.0.226
+
+[type_softlayer_virtual_guest]
+10.0.0.7
+
+[type_vsphere_virtual_machine]
+10.20.30.40
+
+[webserver]
+192.168.0.3
 
 `
 
@@ -467,25 +467,6 @@ func TestHostCommand(t *testing.T) {
 	assert.Equal(t, exp, act)
 }
 
-//	I can't check is inventory are correct, so we need to do that chack with ansible
-//  PLAY [all] *******************************************
-//
-//  TASK [show ids] **************************************
-//  ok: [10.20.30.40] => {
-//  "msg": [
-//  1,
-//  2,
-//  3,
-//  4
-//  ]
-//  }
-//
-//  TASK [show map] ***************************************
-//  ok: [10.20.30.40] => {
-//  "msg": {
-//  "key": "value"
-//  }
-//  }
 func TestInventoryCommand(t *testing.T) {
 	var s state
 	r := strings.NewReader(exampleStateFile)
@@ -498,13 +479,5 @@ func TestInventoryCommand(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "", stderr.String())
 
-	assert.Equal(t, helperCountCharInStrings(expectedInventoryOutput), helperCountCharInStrings(stdout.String()))
-}
-
-func helperCountCharInStrings(str string) map[rune]int {
-	result := map[rune]int{}
-	for _, i := range str {
-		result[i]++
-	}
-	return result
+	assert.Equal(t, expectedInventoryOutput, stdout.String())
 }


### PR DESCRIPTION
I receive a error when I try to use list in output variables: 

```
[all:vars]
panic: interface conversion: interface {} is []interface {}, not string

goroutine 1 [running]:
main.cmdInventory(0x11d35c0, 0xc42000c018, 0x11d35c0, 0xc42000c020, 0xc42000a0e0, 0x0)
	/Users/me/go/src/github.com/adammck/terraform-inventory/cli.go:77 +0x65a
main.main()
	/Users/me/go/src/github.com/adammck/terraform-inventory/main.go:100 +0x4be
```