### PR TITLE
Return an empty hash for unknown hosts

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -104,7 +104,7 @@ func cmdHost(stdout io.Writer, stderr io.Writer, s *state, hostname string) int 
 		}
 	}
 
-	fmt.Fprintf(stderr, "No such host: %s\n", hostname)
+	fmt.Fprintf(stdout, "{}")
 	return 1
 }
 


### PR DESCRIPTION
When using a static inventory that declares new hosts alongside a
dynamic inventory provided by this utility, ansible will call the
dynamic inventory with `--host <host>` to merge in additional vars
that may have been provided by the dynamic inventory.

The default behaviour of *terraform-inventory* is to output an error
message when an unknown host is encountered, breaking this
functionality.

The correct behaviour is to return an empty hash implying there are
no additional vars for this host.