### PR TITLE
Meta hostvars

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -9,7 +9,6 @@ import (
 
 type allGroup struct {
 	Hosts []string               `json:"hosts"`
-	Vars  map[string]interface{} `json:"vars"`
 }
 
 func appendUniq(strs []string, item string) []string {
@@ -27,7 +26,7 @@ func appendUniq(strs []string, item string) []string {
 
 func gatherResources(s *state) map[string]interface{} {
 	groups := make(map[string]interface{}, 0)
-	all_group := allGroup{Vars: make(map[string]interface{}), Hosts: make([]string, 0)}
+	all_group := allGroup{Hosts: make([]string, 0)}
 	groups["all"] = &all_group
 
 	for _, res := range s.resources() {
@@ -43,11 +42,6 @@ func gatherResources(s *state) map[string]interface{} {
 		}
 	}
 
-	if len(s.outputs()) > 0 {
-		for _, out := range s.outputs() {
-			all_group.Vars[out.keyName] = out.value
-		}
-	}
 	return groups
 }
 
@@ -70,11 +64,6 @@ func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
 			writeLn("["+group+"]", stdout, stderr)
 			for _, item := range grp.Hosts {
 				writeLn(item, stdout, stderr)
-			}
-			writeLn("", stdout, stderr)
-			writeLn("["+group+":vars]", stdout, stderr)
-			for key, item := range grp.Vars {
-				writeLn(key+"="+item.(string), stdout, stderr)
 			}
 		}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -270,7 +270,9 @@ const expectedListOutput = `
 	"webserver": ["192.168.0.3"],
 	"staging": ["192.168.0.3"],
 	"status_superserver": ["10.120.0.226"],
-	"database": ["10.0.0.8"]
+	"database": ["10.0.0.8"],
+
+	"_meta": {"hostvars": {}}
 }
 `
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -231,13 +231,7 @@ const expectedListOutput = `
 			"10.20.30.40",
 			"192.168.0.3",
 			"50.0.0.1"
-		],
-		"vars": {
-			"datacenter": "mydc",
-			"olddatacenter": "<0.7_format",
-			"ids": [1, 2, 3, 4],
-			"map": {"key": "value"}
-		}
+		]
 	},
 	"one":   ["10.0.0.1", "10.0.1.1"],
 	"dup":   ["10.0.0.1"],


### PR DESCRIPTION
## Problem

Ansible is super slow with dynamic inventories if you don't have `_meta.hostvars` present.

## Solution

Provide `_meta.hostvars` in the `--list` output.

### Background

https://github.com/ansible/ansible/issues/22633
http://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html#tuning-the-external-inventory-script