### PR TITLE
Skip % when parsing OpenStack metadata

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -121,7 +121,10 @@ func (r Resource) Tags() map[string]string {
 	case "openstack_compute_instance_v2":
 		for k, v := range r.Attributes() {
 			parts := strings.SplitN(k, ".", 2)
-			if len(parts) == 2 && parts[0] == "metadata" && parts[1] != "#" {
+			// At some point Terraform changed the key for counts of attributes to end with ".%"
+			// instead of ".#". Both need to be considered as Terraform still supports state
+			// files using the old format.
+			if len(parts) == 2 && parts[0] == "metadata" && parts[1] != "#" && parts[1] != "%" {
 				kk := strings.ToLower(parts[1])
 				vv := strings.ToLower(v)
 				t[kk] = vv


### PR DESCRIPTION
Hi, there.
Just to have a clean output.
Thanks
Jacopo