### PR TITLE
Add public_ipv6 to keyNames

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -18,6 +18,7 @@ func init() {
 	keyNames = []string{
 		"ipv4_address",                                        // DO and SoftLayer
 		"public_ip",                                           // AWS
+		"public_ipv6",                                         // Scaleway
 		"private_ip",                                          // AWS
 		"ipaddress",                                           // CS
 		"ip_address",                                          // VMware


### PR DESCRIPTION
Scaleway servers should be reachable through ipv6 if they don't have a
public_ip attribute.