### PR TITLE
Add note that the docker provider is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ Terraform, then (re-)provision them with Ansible.
 The following providers are supported:
 
 * AWS
-* DigitalOcean 
 * CloudStack 
-* VMware 
-* OpenStack 
-* Google Compute Engine 
-* SoftLayer
+* DigitalOcean 
+* Docker
 * Exoscale
+* Google Compute Engine 
+* OpenStack 
 * Scaleway
+* SoftLayer
+* VMware 
 
 It's very simple to add support for new providers. See pull requests with the
 [provider][pv] label for examples.

--- a/resource.go
+++ b/resource.go
@@ -21,7 +21,7 @@ func init() {
 		"public_ipv6",                                         // Scaleway
 		"private_ip",                                          // AWS
 		"ipaddress",                                           // CS
-		"ip_address",                                          // VMware
+		"ip_address",                                          // VMware, Docker
 		"network_interface.0.ipv4_address",                    // VMware
 		"default_ip_address",                                  // provider.vsphere v1.1.1
 		"access_ip_v4",                                        // OpenStack


### PR DESCRIPTION
Also ordered providers in README alphabetically to be user friendly.

The ip address field structure is the same as it is for the VMWare provider.