### PR TITLE
VSphere tags in inventory

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -53,6 +53,7 @@ func gatherResources(s *state) map[string]interface{} {
 
 	unsortedOrdered := make(map[string][]*Resource)
 
+	idnames := s.mapidnames()
 	for _, res := range s.resources() {
 		// place in list of all resources
 		all.Hosts = appendUniq(all.Hosts, res.Address())
@@ -76,6 +77,9 @@ func gatherResources(s *state) map[string]interface{} {
 			tag := k
 			if v != "" {
 				tag = fmt.Sprintf("%s_%s", k, v)
+			}
+			if _, exists := idnames[v]; exists {
+				tag = idnames[v]
 			}
 			tags[tag] = appendUniq(tags[tag], res.Address())
 		}

--- a/cli.go
+++ b/cli.go
@@ -53,7 +53,7 @@ func gatherResources(s *state) map[string]interface{} {
 
 	unsortedOrdered := make(map[string][]*Resource)
 
-	idnames := s.mapidnames()
+	resourceIDNames := s.mapResourceIDNames()
 	for _, res := range s.resources() {
 		// place in list of all resources
 		all.Hosts = appendUniq(all.Hosts, res.Address())
@@ -78,8 +78,9 @@ func gatherResources(s *state) map[string]interface{} {
 			if v != "" {
 				tag = fmt.Sprintf("%s_%s", k, v)
 			}
-			if _, exists := idnames[v]; exists {
-				tag = idnames[v]
+			// if v is a resource ID, then tag should be resource name
+			if _, exists := resourceIDNames[v]; exists {
+				tag = resourceIDNames[v]
 			}
 			tags[tag] = appendUniq(tags[tag], res.Address())
 		}

--- a/parser.go
+++ b/parser.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"sort"
+	"strings"
 )
 
 type state struct {
@@ -52,13 +53,26 @@ func (s *state) outputs() []*Output {
 	return inst
 }
 
+func (s *state) mapidnames() map[string]string {
+	t := map[string]string{}
+
+	for _, m := range s.Modules {
+		for _, k := range m.resourceKeys() {
+			if m.ResourceStates[k].Primary.ID != "" && m.ResourceStates[k].Primary.Attributes["name"] != "" {
+				kk := strings.ToLower(m.ResourceStates[k].Primary.ID)
+				t[kk] = m.ResourceStates[k].Primary.Attributes["name"]
+			}
+		}
+	}
+	return t
+}
+
 // resources returns a slice of the Resources found in the statefile.
 func (s *state) resources() []*Resource {
 	inst := make([]*Resource, 0)
 
 	for _, m := range s.Modules {
 		for _, k := range m.resourceKeys() {
-
 			// Terraform stores resources in a name->map map, but we need the name to
 			// decide which groups to include the resource in. So wrap it in a higher-
 			// level object with both properties.

--- a/parser.go
+++ b/parser.go
@@ -53,7 +53,8 @@ func (s *state) outputs() []*Output {
 	return inst
 }
 
-func (s *state) mapidnames() map[string]string {
+// map of resource ID -> resource Name
+func (s *state) mapResourceIDNames() map[string]string {
 	t := map[string]string{}
 
 	for _, m := range s.Modules {

--- a/parser_test.go
+++ b/parser_test.go
@@ -283,6 +283,15 @@ const exampleStateFile = `
 					},
 					"deposed": [],
 					"provider": "provider.scaleway"
+				},
+				"vsphere_virtual_machine.twelve": {
+					"type": "vsphere_virtual_machine",
+					"primary": {
+						"id": "422cfa4a-c6bb-3405-0335-2d9b2034405f",
+						"attributes": {
+							"default_ip_address": "10.20.30.50"
+						}
+					}
 				}
 			}
 		}
@@ -303,9 +312,10 @@ const expectedListOutput = `
 			"10.0.1.1",
 			"10.120.0.226",
 			"10.2.1.5",
+			"10.20.30.40",
 			"192.168.0.3",
 			"50.0.0.1",
-			"10.20.30.40"
+			"10.20.30.50"
 		],
 		"vars": {
 			"datacenter": "mydc",
@@ -326,6 +336,7 @@ const expectedListOutput = `
 	"nine": ["10.0.0.9"],
 	"ten": ["10.0.0.10"],
 	"eleven": ["10.0.0.11"],
+	"twelve": ["10.20.30.50"],
 
 	"one.0":   ["10.0.0.1"],
 	"dup.0":   ["10.0.0.1"],
@@ -340,11 +351,12 @@ const expectedListOutput = `
 	"nine.0":  ["10.0.0.9"],
 	"ten.0":   ["10.0.0.10"],
 	"eleven.0": ["10.0.0.11"],
+	"twelve.0": ["10.20.30.50"],
 
 	"type_aws_instance":                  ["10.0.0.1", "10.0.1.1", "50.0.0.1"],
 	"type_digitalocean_droplet":          ["192.168.0.3"],
 	"type_cloudstack_instance":           ["10.2.1.5"],
-	"type_vsphere_virtual_machine":       ["10.20.30.40"],
+	"type_vsphere_virtual_machine":       ["10.20.30.40", "10.20.30.50"],
 	"type_openstack_compute_instance_v2": ["10.120.0.226"],
 	"type_softlayer_virtual_guest":       ["10.0.0.7"],
 	"type_exoscale_compute":              ["10.0.0.9"],
@@ -373,9 +385,10 @@ const expectedInventoryOutput = `[all]
 10.0.1.1
 10.120.0.226
 10.2.1.5
+10.20.30.40
 192.168.0.3
 50.0.0.1
-10.20.30.40
+10.20.30.50
 
 [all:vars]
 datacenter="mydc"
@@ -474,6 +487,12 @@ olddatacenter="\u003c0.7_format"
 [three.0]
 192.168.0.3
 
+[twelve]
+10.20.30.50
+
+[twelve.0]
+10.20.30.50
+
 [two]
 50.0.0.1
 
@@ -511,6 +530,7 @@ olddatacenter="\u003c0.7_format"
 
 [type_vsphere_virtual_machine]
 10.20.30.40
+10.20.30.50
 
 [webserver]
 192.168.0.3

--- a/parser_test.go
+++ b/parser_test.go
@@ -289,10 +289,21 @@ const exampleStateFile = `
 					"primary": {
 						"id": "422cfa4a-c6bb-3405-0335-2d9b2034405f",
 						"attributes": {
-							"default_ip_address": "10.20.30.50"
+							"default_ip_address": "10.20.30.50",
+							"tags.#": "1",
+                            "tags.1357913579": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL"
 						}
 					}
-				}
+				},
+				"data.vsphere_tag.testTag1": {
+                    "type": "vsphere_tag",
+                    "primary": {
+                        "id": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL",
+                        "attributes": {
+                            "name": "testTag1"
+                        }
+                    }
+                }
 			}
 		}
 	]
@@ -337,6 +348,7 @@ const expectedListOutput = `
 	"ten": ["10.0.0.10"],
 	"eleven": ["10.0.0.11"],
 	"twelve": ["10.20.30.50"],
+	"testTag1": ["10.20.30.50"],
 
 	"one.0":   ["10.0.0.1"],
 	"dup.0":   ["10.0.0.1"],
@@ -480,6 +492,9 @@ olddatacenter="\u003c0.7_format"
 
 [ten.0]
 10.0.0.10
+
+[testTag1]
+10.20.30.50
 
 [three]
 192.168.0.3

--- a/parser_test.go
+++ b/parser_test.go
@@ -291,19 +291,19 @@ const exampleStateFile = `
 						"attributes": {
 							"default_ip_address": "10.20.30.50",
 							"tags.#": "1",
-                            "tags.1357913579": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL"
+							"tags.1357913579": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL"
 						}
 					}
 				},
 				"data.vsphere_tag.testTag1": {
-                    "type": "vsphere_tag",
-                    "primary": {
-                        "id": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL",
-                        "attributes": {
-                            "name": "testTag1"
-                        }
-                    }
-                }
+					"type": "vsphere_tag",
+					"primary": {
+						"id": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL",
+						"attributes": {
+							"name": "testTag1"
+						}
+					}
+				}
 			}
 		}
 	]

--- a/resource.go
+++ b/resource.go
@@ -23,6 +23,7 @@ func init() {
 		"ipaddress",                                           // CS
 		"ip_address",                                          // VMware
 		"network_interface.0.ipv4_address",                    // VMware
+		"default_ip_address",                                  // provider.vsphere v1.1.1
 		"access_ip_v4",                                        // OpenStack
 		"floating_ip",                                         // OpenStack
 		"network_interface.0.access_config.0.nat_ip",          // GCE

--- a/resource.go
+++ b/resource.go
@@ -123,7 +123,13 @@ func (r Resource) Tags() map[string]string {
 	case "vsphere_virtual_machine":
 		for k, v := range r.Attributes() {
 			parts := strings.SplitN(k, ".", 2)
+
 			if len(parts) == 2 && parts[0] == "custom_configuration_parameters" && parts[1] != "#" && parts[1] != "%" {
+				kk := strings.ToLower(parts[1])
+				vv := strings.ToLower(v)
+				t[kk] = vv
+			}
+			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "#" && parts[1] != "%" {
 				kk := strings.ToLower(parts[1])
 				vv := strings.ToLower(v)
 				t[kk] = vv


### PR DESCRIPTION
I'm using terraform with VSphere provider.

```
$ terraform version
Terraform v0.11.1
+ provider.vsphere v1.1.1
```

And I use tags : https://www.terraform.io/docs/providers/vsphere/d/tag.html

In my terraform.tfstate file the tag names are not directly in the resources.
```
    "vsphere_virtual_machine.twelve": {
        "type": "vsphere_virtual_machine",
        "primary": {
            "id": "422cfa4a-c6bb-3405-0335-2d9b2034405f",
            "attributes": {
                "default_ip_address": "10.20.30.50",
                "tags.#": "1",
                "tags.1357913579": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL"
            }
        }
    },
    "data.vsphere_tag.testTag1": {
        "type": "vsphere_tag",
        "primary": {
            "id": "urn:vmomi:InventoryServiceTag:00000000-0001-4957-81fa-1234567890ab:GLOBAL",
            "attributes": {
                "name": "testTag1"
            }
        }
    }
```                


To solve this, I create a map of ID => name of all resources.
And during "inventorize tags", I look for "ID" in the map to replace with tag name.
