### PR TITLE
Add support for AWS spot instance

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -395,6 +395,18 @@ const exampleStateFile = `
 							"primary_ip": "10.0.0.16"
 						}
 					}
+				},
+				"aws_spot_instance_request.seventeen": {
+					"type": "aws_spot_instance_request",
+					"primary": {
+						"id": "i-a1a1a1a1",
+						"attributes": {
+							"id": "sir-a1a1a1a1",
+							"public_ip": "50.0.0.17",
+							"tags.%": "1",
+							"tags.Role": "worker"
+						}
+					}
 				}
 			}
 		}
@@ -421,6 +433,7 @@ const expectedListOutput = `
 			"192.168.0.3",
 			"192.168.102.14",
 			"50.0.0.1",
+			"50.0.0.17",
 			"10.20.30.50"
 		],
 		"vars": {
@@ -447,6 +460,7 @@ const expectedListOutput = `
 	"thirteen": ["10.0.0.13"],
 	"fourteen": ["192.168.102.14"],
 	"sixteen": ["10.0.0.16"],
+	"seventeen": ["50.0.0.17"],
 
 	"one.0":   ["10.0.0.1"],
 	"dup.0":   ["10.0.0.1"],
@@ -465,6 +479,7 @@ const expectedListOutput = `
 	"thirteen.0": ["10.0.0.13"],
 	"fourteen.0": ["192.168.102.14"],
 	"sixteen.0": ["10.0.0.16"],
+	"seventeen.0": ["50.0.0.17"],
 
 	"type_aws_instance":                  ["10.0.0.1", "10.0.1.1", "50.0.0.1"],
 	"type_digitalocean_droplet":          ["192.168.0.3"],
@@ -479,10 +494,12 @@ const expectedListOutput = `
 	"type_scaleway_server":               ["10.0.0.11"],
 	"type_packet_device":                 ["10.0.0.13"],
 	"type_libvirt_domain":                ["192.168.102.14"],
+	"type_aws_spot_instance_request":			["50.0.0.17"],
 
 	"role_rrrrrrrr": ["10.20.30.40"],
 	"role_web": ["10.0.0.1"],
 	"role_test": ["10.0.0.10"],
+	"role_worker": ["50.0.0.17"],
 	"webserver": ["192.168.0.3"],
 	"staging": ["192.168.0.3"],
 	"status_superserver": ["10.120.0.226"],
@@ -507,6 +524,7 @@ const expectedInventoryOutput = `[all]
 192.168.0.3
 192.168.102.14
 50.0.0.1
+50.0.0.17
 10.20.30.50
 
 [all:vars]
@@ -579,6 +597,9 @@ olddatacenter="\u003c0.7_format"
 [role_web]
 10.0.0.1
 
+[role_worker]
+50.0.0.17
+
 [scw_test]
 10.0.0.11
 
@@ -587,6 +608,12 @@ olddatacenter="\u003c0.7_format"
 
 [seven.0]
 10.0.0.7
+
+[seventeen]
+50.0.0.17
+
+[seventeen.0]
+50.0.0.17
 
 [six]
 10.120.0.226
@@ -643,6 +670,9 @@ olddatacenter="\u003c0.7_format"
 10.0.0.1
 10.0.1.1
 50.0.0.1
+
+[type_aws_spot_instance_request]
+50.0.0.17
 
 [type_cloudstack_instance]
 10.2.1.5

--- a/resource.go
+++ b/resource.go
@@ -123,6 +123,18 @@ func (r Resource) Tags() map[string]string {
 				t[kk] = vv
 			}
 		}
+	case "aws_spot_instance_request":
+		for k, v := range r.Attributes() {
+			parts := strings.SplitN(k, ".", 2)
+			// At some point Terraform changed the key for counts of attributes to end with ".%"
+			// instead of ".#". Both need to be considered as Terraform still supports state
+			// files using the old format.
+			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "#" && parts[1] != "%" {
+				kk := strings.ToLower(parts[1])
+				vv := strings.ToLower(v)
+				t[kk] = vv
+			}
+		}
 	case "vsphere_virtual_machine":
 		for k, v := range r.Attributes() {
 			parts := strings.SplitN(k, ".", 2)


### PR DESCRIPTION
The idea is to use [aws_spot_instance_request](https://www.terraform.io/docs/providers/aws/r/spot_instance_request.html) terraform resources, the same way as we do for `aws_instance` resources.

For instance, this spot request:

```tf
resource "aws_spot_instance_request" "cheap_worker" {
  ami                  = "ami-1234"
  key_name             = "cheap-worker-ssh-key"
  security_groups      = ["cheap-worker-security-group"]
  wait_for_fulfillment = true
  spot_type            = "one-time"
  instance_type        = "t3.medium"

  tags {
    Role = "cheap-worker"
  }
}
```

Will match later in ansible-playbook using the defined Role:

```yaml
---
- hosts: role_cheap-worker
  remote_user: ubuntu
  become: yes
  become_user: root
  tasks:
    - name: install apps
       apt: name=cowsay update_cache=yes
```