### PR TITLE
Support Terraform 0.12 state format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
+  - "1.8"
+  - "1.11.x"
+  - "1.x" # latest
 
 script:
   - go test -v ./...

--- a/cli.go
+++ b/cli.go
@@ -42,7 +42,107 @@ func appendUniq(strs []string, item string) []string {
 	return strs
 }
 
-func gatherResources(s *state) map[string]interface{} {
+func gatherResources(s *stateAnyTerraformVersion) map[string]interface{} {
+	if s.TerraformVersion == TerraformVersionPre0dot12 {
+		return gatherResourcesPre0dot12(&s.StatePre0dot12)
+	} else if s.TerraformVersion == TerraformVersion0dot12 {
+		return gatherResources0dot12(&s.State0dot12)
+	} else {
+		panic("Unimplemented Terraform version enum")
+	}
+}
+
+func gatherResourcesPre0dot12(s *state) map[string]interface{} {
+	outputGroups := make(map[string]interface{})
+
+	all := &allGroup{Hosts: make([]string, 0), Vars: make(map[string]interface{})}
+	types := make(map[string][]string)
+	individual := make(map[string][]string)
+	ordered := make(map[string][]string)
+	tags := make(map[string][]string)
+
+	unsortedOrdered := make(map[string][]*Resource)
+
+	resourceIDNames := s.mapResourceIDNames()
+	for _, res := range s.resources() {
+		// place in list of all resources
+		all.Hosts = appendUniq(all.Hosts, res.Hostname())
+
+		// place in list of resource types
+		tp := fmt.Sprintf("type_%s", res.resourceType)
+		types[tp] = appendUniq(types[tp], res.Hostname())
+
+		unsortedOrdered[res.baseName] = append(unsortedOrdered[res.baseName], res)
+
+		// store as invdividual host (eg. <name>.<count>)
+		invdName := fmt.Sprintf("%s.%d", res.baseName, res.counter)
+		if old, exists := individual[invdName]; exists {
+			fmt.Fprintf(os.Stderr, "overwriting already existing individual key %s, old: %v, new: %v\n", invdName, old, res.Hostname())
+		}
+		individual[invdName] = []string{res.Hostname()}
+
+		// inventorize tags
+		for k, v := range res.Tags() {
+			// Valueless
+			tag := k
+			if v != "" {
+				tag = fmt.Sprintf("%s_%s", k, v)
+			}
+			// if v is a resource ID, then tag should be resource name
+			if _, exists := resourceIDNames[v]; exists {
+				tag = resourceIDNames[v]
+			}
+			tags[tag] = appendUniq(tags[tag], res.Hostname())
+		}
+	}
+
+	// inventorize outputs as variables
+	if len(s.outputs()) > 0 {
+		for _, out := range s.outputs() {
+			all.Vars[out.keyName] = out.value
+		}
+	}
+
+	// sort the ordered groups
+	for basename, resources := range unsortedOrdered {
+		cs := counterSorter{resources}
+		sort.Sort(cs)
+
+		for i := range resources {
+			ordered[basename] = append(ordered[basename], resources[i].Hostname())
+		}
+	}
+
+	outputGroups["all"] = all
+	for k, v := range individual {
+		if old, exists := outputGroups[k]; exists {
+			fmt.Fprintf(os.Stderr, "individual overwriting already existing output with key %s, old: %v, new: %v", k, old, v)
+		}
+		outputGroups[k] = v
+	}
+	for k, v := range ordered {
+		if old, exists := outputGroups[k]; exists {
+			fmt.Fprintf(os.Stderr, "ordered overwriting already existing output with key %s, old: %v, new: %v", k, old, v)
+		}
+		outputGroups[k] = v
+	}
+	for k, v := range types {
+		if old, exists := outputGroups[k]; exists {
+			fmt.Fprintf(os.Stderr, "types overwriting already existing output key %s, old: %v, new: %v", k, old, v)
+		}
+		outputGroups[k] = v
+	}
+	for k, v := range tags {
+		if old, exists := outputGroups[k]; exists {
+			fmt.Fprintf(os.Stderr, "tags overwriting already existing output key %s, old: %v, new: %v", k, old, v)
+		}
+		outputGroups[k] = v
+	}
+
+	return outputGroups
+}
+
+func gatherResources0dot12(s *stateTerraform0dot12) map[string]interface{} {
 	outputGroups := make(map[string]interface{})
 
 	all := &allGroup{Hosts: make([]string, 0), Vars: make(map[string]interface{})}
@@ -132,11 +232,11 @@ func gatherResources(s *state) map[string]interface{} {
 	return outputGroups
 }
 
-func cmdList(stdout io.Writer, stderr io.Writer, s *state) int {
+func cmdList(stdout io.Writer, stderr io.Writer, s *stateAnyTerraformVersion) int {
 	return output(stdout, stderr, gatherResources(s))
 }
 
-func cmdInventory(stdout io.Writer, stderr io.Writer, s *state) int {
+func cmdInventory(stdout io.Writer, stderr io.Writer, s *stateAnyTerraformVersion) int {
 	groups := gatherResources(s)
 	group_names := []string{}
 	for group, _ := range groups {
@@ -190,7 +290,7 @@ func checkErr(err error, stderr io.Writer) int {
 	return 0
 }
 
-func cmdHost(stdout io.Writer, stderr io.Writer, s *state, hostname string) int {
+func cmdHost(stdout io.Writer, stderr io.Writer, s *stateAnyTerraformVersion, hostname string) int {
 	for _, res := range s.resources() {
 		if hostname == res.Hostname() {
 			attributes := res.Attributes()

--- a/output.go
+++ b/output.go
@@ -15,7 +15,7 @@ func NewOutput(keyName string, value interface{}) (*Output, error) {
 
 	// TODO: Warn instead of silently ignore error?
 	if len(keyName) == 0 {
-		return nil, fmt.Errorf("couldn't parse keyName: %s", keyName)
+		return nil, fmt.Errorf("couldn't parse output keyName: %s", keyName)
 	}
 
 	return &Output{

--- a/parser.go
+++ b/parser.go
@@ -2,29 +2,93 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
 )
 
+// TerraformVersion defines which version of Terraform state applies
+type TerraformVersion int
+
+const (
+	// TerraformVersionUnknown means unknown version
+	TerraformVersionUnknown TerraformVersion = 0
+
+	// TerraformVersionPre0dot12 means < 0.12
+	TerraformVersionPre0dot12 TerraformVersion = 1
+
+	// TerraformVersion0dot12 means >= 0.12
+	TerraformVersion0dot12 TerraformVersion = 2
+)
+
+type stateAnyTerraformVersion struct {
+	StatePre0dot12   state
+	State0dot12      stateTerraform0dot12
+	TerraformVersion TerraformVersion
+}
+
+// Terraform < v0.12
 type state struct {
 	Modules []moduleState `json:"modules"`
 }
+type moduleState struct {
+	Path           []string                 `json:"path"`
+	ResourceStates map[string]resourceState `json:"resources"`
+	Outputs        map[string]interface{}   `json:"outputs"`
+}
+type resourceState struct {
+	// Populated from statefile
+	Type    string        `json:"type"`
+	Primary instanceState `json:"primary"`
+}
+type instanceState struct {
+	ID         string            `json:"id"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+// Terraform <= v0.12
+type stateTerraform0dot12 struct {
+	Values valuesStateTerraform0dot12 `json:"values"`
+}
+type valuesStateTerraform0dot12 struct {
+	RootModule *moduleStateTerraform0dot12 `json:"root_module"`
+	Outputs    map[string]interface{}      `json:"outputs"`
+}
+type moduleStateTerraform0dot12 struct {
+	ResourceStates []resourceStateTerraform0dot12 `json:"resources"`
+	ChildModules   []moduleStateTerraform0dot12   `json:"child_modules"`
+	Address        string                         `json:"address"` // empty for root module, else e.g. `module.mymodulename`
+}
+type resourceStateTerraform0dot12 struct {
+	Address   string                 `json:"address"`
+	Name      string                 `json:"name"`
+	RawValues map[string]interface{} `json:"values"`
+	Type      string                 `json:"type"`
+}
 
 // read populates the state object from a statefile.
-func (s *state) read(stateFile io.Reader) error {
+func (s *stateAnyTerraformVersion) read(stateFile io.Reader) error {
+	s.TerraformVersion = TerraformVersionUnknown
 
-	// read statefile contents
-	b, err := ioutil.ReadAll(stateFile)
-	if err != nil {
-		return err
+	b, readErr := ioutil.ReadAll(stateFile)
+	if readErr != nil {
+		return readErr
 	}
 
-	// parse into struct
-	err = json.Unmarshal(b, s)
-	if err != nil {
-		return err
+	err0dot12 := json.Unmarshal(b, &(*s).State0dot12)
+	if err0dot12 == nil && s.State0dot12.Values.RootModule != nil {
+		s.TerraformVersion = TerraformVersion0dot12
+	} else {
+		errPre0dot12 := json.Unmarshal(b, &(*s).StatePre0dot12)
+		if errPre0dot12 == nil && s.StatePre0dot12.Modules != nil {
+			s.TerraformVersion = TerraformVersionPre0dot12
+		} else {
+			return fmt.Errorf("0.12 format error: %v; pre-0.12 format error: %v (nil error means no content/modules found in the respective format)", err0dot12, errPre0dot12)
+		}
 	}
 
 	return nil
@@ -53,6 +117,25 @@ func (s *state) outputs() []*Output {
 	return inst
 }
 
+// outputs returns a slice of the Outputs found in the statefile.
+func (s *stateTerraform0dot12) outputs() []*Output {
+	inst := make([]*Output, 0)
+
+	for k, v := range s.Values.Outputs {
+		var o *Output
+		switch v := v.(type) {
+		case map[string]interface{}:
+			o, _ = NewOutput(k, v["value"])
+		default: // not expected
+			o, _ = NewOutput(k, "<error>")
+		}
+
+		inst = append(inst, o)
+	}
+
+	return inst
+}
+
 // map of resource ID -> resource Name
 func (s *state) mapResourceIDNames() map[string]string {
 	t := map[string]string{}
@@ -68,17 +151,91 @@ func (s *state) mapResourceIDNames() map[string]string {
 	return t
 }
 
+// map of resource ID -> resource Name
+func (s *stateTerraform0dot12) mapResourceIDNames() map[string]string {
+	t := map[string]string{}
+
+	for _, module := range s.getAllModules() {
+		for _, resourceState := range module.ResourceStates {
+			id, typeOk := resourceState.RawValues["id"].(string)
+			if typeOk && id != "" && resourceState.Name != "" {
+				k := strings.ToLower(id)
+				t[k] = resourceState.Name
+			}
+		}
+	}
+
+	return t
+}
+
+func (s *stateTerraform0dot12) getAllModules() []*moduleStateTerraform0dot12 {
+	var allModules []*moduleStateTerraform0dot12
+	allModules = append(allModules, s.Values.RootModule)
+	addChildModules(&allModules, s.Values.RootModule)
+	return allModules
+}
+
+// recursively adds all child modules to the slice
+func addChildModules(out *[]*moduleStateTerraform0dot12, from *moduleStateTerraform0dot12) {
+	for i := range from.ChildModules {
+		addChildModules(out, &from.ChildModules[i])
+		*out = append(*out, &from.ChildModules[i])
+	}
+}
+
+// resources returns a slice of the Resources found in the statefile.
+func (s *stateAnyTerraformVersion) resources() []*Resource {
+	switch s.TerraformVersion {
+	case TerraformVersionPre0dot12:
+		return s.StatePre0dot12.resources()
+	case TerraformVersion0dot12:
+		return s.State0dot12.resources()
+	case TerraformVersionUnknown:
+	}
+	panic("Unimplemented Terraform version enum")
+}
+
 // resources returns a slice of the Resources found in the statefile.
 func (s *state) resources() []*Resource {
 	inst := make([]*Resource, 0)
 
 	for _, m := range s.Modules {
 		for _, k := range m.resourceKeys() {
+			if strings.HasPrefix(k, "data.") {
+				// This does not represent a host (e.g. AWS AMI)
+				continue
+			}
+
+			// If a module is used, the resource key may not be unique, for instance:
+			//
+			// The module cannot use dynamic resource naming and thus has to use some hardcoded name:
+			//
+			//     resource "aws_instance" "host" { ... }
+			//
+			// The main file then uses the module twice:
+			//
+			//     module "application1" { source = "./modules/mymodulename" }
+			//     module "application2" { source = "./modules/mymodulename" }
+			//
+			// Avoid key clashes by prepending module name to the key. If path is ["root"], don't
+			// prepend anything.
+			//
+			// In the above example: `aws_instance.host` -> `aws_instance.application1_host`
+			fullKey := k
+			resourceNameIndex := strings.Index(fullKey, ".") + 1
+			if len(m.Path) > 1 && resourceNameIndex > 0 {
+				for i := len(m.Path) - 1; i >= 1; i-- {
+					fullKey = fullKey[:resourceNameIndex] + strings.Replace(m.Path[i], ".", "_", -1) + "_" + fullKey[resourceNameIndex:]
+				}
+			}
+
 			// Terraform stores resources in a name->map map, but we need the name to
 			// decide which groups to include the resource in. So wrap it in a higher-
 			// level object with both properties.
-			r, err := NewResource(k, m.ResourceStates[k])
+			r, err := NewResource(fullKey, m.ResourceStates[k])
 			if err != nil {
+				asJSON, _ := json.Marshal(m.ResourceStates[k])
+				fmt.Fprintf(os.Stderr, "Warning: failed to parse resource %s (%v)\n", asJSON, err)
 				continue
 			}
 			if r.IsSupported() {
@@ -90,9 +247,78 @@ func (s *state) resources() []*Resource {
 	return inst
 }
 
-type moduleState struct {
-	ResourceStates map[string]resourceState `json:"resources"`
-	Outputs        map[string]interface{}   `json:"outputs"`
+func encodeTerraform0Dot12ValuesAsAttributes(rawValues *map[string]interface{}) map[string]string {
+	ret := make(map[string]string)
+	for k, v := range *rawValues {
+		switch v := v.(type) {
+		case map[string]interface{}:
+			ret[k+".#"] = strconv.Itoa(len(v))
+			for kk, vv := range v {
+				if str, typeOk := vv.(string); typeOk {
+					ret[k+"."+kk] = str
+				} else {
+					ret[k+"."+kk] = "<error>"
+				}
+			}
+		case string:
+			ret[k] = v
+		default:
+			ret[k] = "<error>"
+		}
+	}
+	return ret
+}
+
+// resources returns a slice of the Resources found in the statefile.
+func (s *stateTerraform0dot12) resources() []*Resource {
+	inst := make([]*Resource, 0)
+
+	for _, module := range s.getAllModules() {
+		for _, rs := range module.ResourceStates {
+			id, typeOk := rs.RawValues["id"].(string)
+			if !typeOk {
+				continue
+			}
+
+			if strings.HasPrefix(rs.Address, "data.") {
+				// This does not represent a host (e.g. AWS AMI)
+				continue
+			}
+
+			modulePrefix := ""
+			if module.Address != "" {
+				modulePrefix = strings.Replace(module.Address, ".", "_", -1) + "_"
+			}
+			resourceKeyName := rs.Type + "." + modulePrefix + rs.Name
+
+			// Terraform stores resources in a name->map map, but we need the name to
+			// decide which groups to include the resource in. So wrap it in a higher-
+			// level object with both properties.
+			//
+			// Convert to the pre-0.12 structure for backwards compatibility of code.
+			r, err := NewResource(resourceKeyName, resourceState{
+				Type: rs.Type,
+				Primary: instanceState{
+					ID:         id,
+					Attributes: encodeTerraform0Dot12ValuesAsAttributes(&rs.RawValues),
+				},
+			})
+			if err != nil {
+				asJSON, _ := json.Marshal(rs)
+				fmt.Fprintf(os.Stderr, "Warning: failed to parse resource %s (%v)\n", asJSON, err)
+				continue
+			}
+			if r.IsSupported() {
+				inst = append(inst, r)
+			}
+		}
+	}
+
+	sort.Slice(inst, func(i, j int) bool {
+		return inst[i].baseName < inst[j].baseName
+	})
+
+	return inst
 }
 
 // resourceKeys returns a sorted slice of the key names of the resources in this
@@ -105,21 +331,9 @@ func (ms *moduleState) resourceKeys() []string {
 
 	for k := range ms.ResourceStates {
 		keys[i] = k
-		i += 1
+		i++
 	}
 
 	sort.Strings(keys)
 	return keys
-}
-
-type resourceState struct {
-
-	// Populated from statefile
-	Type    string        `json:"type"`
-	Primary instanceState `json:"primary"`
-}
-
-type instanceState struct {
-	ID         string            `json:"id"`
-	Attributes map[string]string `json:"attributes,omitempty"`
 }

--- a/parser.go
+++ b/parser.go
@@ -65,6 +65,7 @@ type moduleStateTerraform0dot12 struct {
 }
 type resourceStateTerraform0dot12 struct {
 	Address   string                 `json:"address"`
+	Index     *int                   `json:"index"` // only set by Terraform for counted resources
 	Name      string                 `json:"name"`
 	RawValues map[string]interface{} `json:"values"`
 	Type      string                 `json:"type"`
@@ -290,6 +291,9 @@ func (s *stateTerraform0dot12) resources() []*Resource {
 				modulePrefix = strings.Replace(module.Address, ".", "_", -1) + "_"
 			}
 			resourceKeyName := rs.Type + "." + modulePrefix + rs.Name
+			if rs.Index != nil {
+				resourceKeyName += "." + strconv.Itoa(*rs.Index)
+			}
 
 			// Terraform stores resources in a name->map map, but we need the name to
 			// decide which groups to include the resource in. So wrap it in a higher-

--- a/parser_test.go
+++ b/parser_test.go
@@ -970,10 +970,26 @@ const exampleStateFileTerraform0dot12 = `
 							"address": "aws_instance.host",
 							"type": "aws_instance",
 							"name": "host",
+							"index": 0,
 							"values": {
 								"ami": "ami-00000000000000001",
 								"id": "i-33333333333333333",
 								"private_ip": "10.0.0.3",
+								"public_ip": "",
+								"tags": {
+									"Name": "three-aws-instance"
+								}
+							}
+						},
+						{
+							"address": "aws_instance.host",
+							"type": "aws_instance",
+							"name": "host",
+							"index": 1,
+							"values": {
+								"ami": "ami-00000000000000001",
+								"id": "i-11133333333333333",
+								"private_ip": "10.0.1.3",
 								"public_ip": "",
 								"tags": {
 									"Name": "three-aws-instance"
@@ -995,6 +1011,7 @@ const expectedListOutputTerraform0dot12 = `
 		"hosts": [
 			"10.0.0.2",
 			"10.0.0.3",
+			"10.0.1.3",
 			"35.159.25.34"
 		],
 		"vars": {
@@ -1008,19 +1025,21 @@ const expectedListOutputTerraform0dot12 = `
 	"module_my-module-two_host.0": ["10.0.0.2"],
 	"module_my-module-two_host": ["10.0.0.2"],
 	"module_my-module-three_host.0": ["10.0.0.3"],
-	"module_my-module-three_host": ["10.0.0.3"],
+	"module_my-module-three_host.1": ["10.0.1.3"],
+	"module_my-module-three_host": ["10.0.0.3", "10.0.1.3"],
 
-	"type_aws_instance": ["10.0.0.2", "10.0.0.3", "35.159.25.34"],
+	"type_aws_instance": ["10.0.0.2", "10.0.0.3", "10.0.1.3", "35.159.25.34"],
 
 	"name_one-aws-instance": ["35.159.25.34"],
 	"name_two-aws-instance": ["10.0.0.2"],
-	"name_three-aws-instance": ["10.0.0.3"]
+	"name_three-aws-instance": ["10.0.0.3", "10.0.1.3"]
 }
 `
 
 const expectedInventoryOutputTerraform0dot12 = `[all]
 10.0.0.2
 10.0.0.3
+10.0.1.3
 35.159.25.34
 
 [all:vars]
@@ -1030,9 +1049,13 @@ my_password="1234"
 
 [module_my-module-three_host]
 10.0.0.3
+10.0.1.3
 
 [module_my-module-three_host.0]
 10.0.0.3
+
+[module_my-module-three_host.1]
+10.0.1.3
 
 [module_my-module-two_host]
 10.0.0.2
@@ -1045,6 +1068,7 @@ my_password="1234"
 
 [name_three-aws-instance]
 10.0.0.3
+10.0.1.3
 
 [name_two-aws-instance]
 10.0.0.2
@@ -1058,6 +1082,7 @@ my_password="1234"
 [type_aws_instance]
 10.0.0.2
 10.0.0.3
+10.0.1.3
 35.159.25.34
 
 `

--- a/parser_test.go.example.tfstate
+++ b/parser_test.go.example.tfstate
@@ -1,0 +1,86 @@
+{
+	"format_version": "0.1",
+	"terraform_version": "0.12.1",
+	"values": {
+		"outputs": {
+			"my_endpoint": {
+				"sensitive": false,
+				"value": "a.b.c.d.example.com"
+			},
+			"my_password": {
+				"sensitive": true,
+				"value": "1234"
+			},
+			"map": {
+				"sensitive": false,
+				"value": {
+					"first": "a",
+					"second": "b"
+				}
+			}
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_instance.one",
+					"type": "aws_instance",
+					"name": "one",
+					"provider_name": "aws",
+					"schema_version": 1,
+					"values": {
+						"ami": "ami-00000000000000000",
+						"id": "i-11111111111111111",
+						"private_ip": "10.0.0.1",
+						"public_ip": "35.159.25.34",
+						"tags": {
+							"Name": "one-aws-instance"
+						},
+						"volume_tags": {
+							"Ignored": "stuff"
+						}
+					}
+				}
+			],
+			"child_modules": [
+				{
+					"resources": [
+						{
+							"address": "aws_instance.host",
+							"type": "aws_instance",
+							"name": "host",
+							"values": {
+								"ami": "ami-00000000000000001",
+								"id": "i-22222222222222222",
+								"private_ip": "10.0.0.2",
+								"public_ip": "",
+								"tags": {
+									"Name": "two-aws-instance"
+								}
+							}
+						}
+					],
+					"address": "module.my-module-two"
+				},
+				{
+					"resources": [
+						{
+							"address": "aws_instance.host",
+							"type": "aws_instance",
+							"name": "host",
+							"values": {
+								"ami": "ami-00000000000000001",
+								"id": "i-33333333333333333",
+								"private_ip": "10.0.0.3",
+								"public_ip": "",
+								"tags": {
+									"Name": "three-aws-instance"
+								}
+							}
+						}
+					],
+					"address": "module.my-module-three"
+				}
+			]
+		}
+	}
+}

--- a/resource.go
+++ b/resource.go
@@ -16,16 +16,16 @@ var nameParser *regexp.Regexp
 
 func init() {
 	keyNames = []string{
-		"ipv4_address",                                        // DO and SoftLayer
-		"public_ip",                                           // AWS
-		"public_ipv6",                                         // Scaleway
-		"ipaddress",                                           // CS
-		"ip_address",                                          // VMware, Docker, Linode
-		"private_ip",                                          // AWS
-		"network_interface.0.ipv4_address",                    // VMware
-		"default_ip_address",                                  // provider.vsphere v1.1.1
-		"access_ip_v4",                                        // OpenStack
-		"floating_ip",                                         // OpenStack
+		"ipv4_address",                     // DO and SoftLayer
+		"public_ip",                        // AWS
+		"public_ipv6",                      // Scaleway
+		"ipaddress",                        // CS
+		"ip_address",                       // VMware, Docker, Linode
+		"private_ip",                       // AWS
+		"network_interface.0.ipv4_address", // VMware
+		"default_ip_address",               // provider.vsphere v1.1.1
+		"access_ip_v4",                     // OpenStack
+		"floating_ip",                      // OpenStack
 		"network_interface.0.access_config.0.nat_ip",          // GCE
 		"network_interface.0.access_config.0.assigned_nat_ip", // GCE
 		"network_interface.0.address",                         // GCE
@@ -38,8 +38,11 @@ func init() {
 		"nic_list.0.ip_endpoint_list.0.ip",                    // Nutanix
 	}
 
-	// type.name.0
-	nameParser = regexp.MustCompile(`^(\w+)\.([\w\-]+)(?:\.(\d+))?$`)
+	// Formats:
+	// - type.[module_]name (no `count` attribute; contains module name if we're not in the root module)
+	// - type.[module_]name.0 (if resource has `count` attribute)
+	// - "data." prefix should not parse and be ignored by caller (does not represent a host)
+	nameParser = regexp.MustCompile(`^([\w\-]+)\.([\w\-]+)(?:\.(\d+))?$`)
 }
 
 type Resource struct {
@@ -62,15 +65,13 @@ func NewResource(keyName string, state resourceState) (*Resource, error) {
 	m := nameParser.FindStringSubmatch(keyName)
 
 	// This should not happen unless our regex changes.
-	// TODO: Warn instead of silently ignore error?
 	if len(m) != 4 {
-		return nil, fmt.Errorf("couldn't parse keyName: %s", keyName)
+		return nil, fmt.Errorf("couldn't parse resource keyName: %s", keyName)
 	}
 
 	var c int
 	var err error
 	if m[3] != "" {
-
 		// The third section should be the index, if it's present. Not sure what
 		// else we can do other than panic (which seems highly undesirable) if that
 		// isn't the case.


### PR DESCRIPTION
Solves https://github.com/adammck/terraform-inventory/issues/113 by implementing basic support for the output of Terraform 0.12's `terraform show -json`. I introduced new JSON-to-struct mappings for 0.12, but kept all old code to remain compatible with old Terraform versions (99% of people probably still use 0.11 right now). Internally, new-style resources are mapped to the existing struct's so almost no code apart from the parser needed any change.