### PR TITLE
Add support for Azure Public IP resource

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -441,6 +441,19 @@ const exampleStateFile = `
 							"tags.#": "0"
 						}
 					}
+				},
+				"azurerm_public_ip.twenty": {
+					"type": "azurerm_public_ip",
+					"depends_on": [],
+					"primary": {
+						"id": "888888899",
+						"attributes": {
+							"id": "888888899",
+							"ip_address": "50.0.0.20",
+							"tags.%": "1",
+							"tags.Role": "azure-worker"
+						}
+					}
 				}
 			}
 		}
@@ -469,6 +482,7 @@ const expectedListOutput = `
 			"192.168.102.14",
 			"50.0.0.1",
 			"50.0.0.17",
+			"50.0.0.20",
 			"80.80.100.124",
 			"10.20.30.50"
 		],
@@ -499,6 +513,7 @@ const expectedListOutput = `
 	"sixteen": ["10.0.0.16"],
 	"seventeen": ["50.0.0.17"],
 	"eighteen": ["80.80.100.124"],
+	"twenty": ["50.0.0.20"],
 
 	"one.0":   ["10.0.0.1"],
 	"dup.0":   ["10.0.0.1"],
@@ -520,6 +535,7 @@ const expectedListOutput = `
 	"sixteen.0": ["10.0.0.16"],
 	"seventeen.0": ["50.0.0.17"],
 	"eighteen.0": ["80.80.100.124"],
+	"twenty.0": ["50.0.0.20"],
 
 	"type_aws_instance":                  ["10.0.0.1", "10.0.1.1", "50.0.0.1"],
 	"type_digitalocean_droplet":          ["192.168.0.3"],
@@ -537,7 +553,9 @@ const expectedListOutput = `
 	"type_libvirt_domain":                ["192.168.102.14"],
 	"type_aws_spot_instance_request":			["50.0.0.17"],
 	"type_linode_instance":               ["80.80.100.124"],
+	"type_azurerm_public_ip":				      ["50.0.0.20"],
 
+	"role_azure-worker": ["50.0.0.20"],
 	"role_nine": ["10.0.0.9"],
 	"role_rrrrrrrr": ["10.20.30.40"],
 	"role_web": ["10.0.0.1"],
@@ -570,6 +588,7 @@ const expectedInventoryOutput = `[all]
 192.168.102.14
 50.0.0.1
 50.0.0.17
+50.0.0.20
 80.80.100.124
 10.20.30.50
 
@@ -645,6 +664,9 @@ olddatacenter="\u003c0.7_format"
 
 [one.1]
 10.0.1.1
+
+[role_azure-worker]
+50.0.0.20
 
 [role_nine]
 10.0.0.9
@@ -724,6 +746,12 @@ olddatacenter="\u003c0.7_format"
 [twelve.0]
 10.20.30.50
 
+[twenty]
+50.0.0.20
+
+[twenty.0]
+50.0.0.20
+
 [two]
 50.0.0.1
 
@@ -737,6 +765,9 @@ olddatacenter="\u003c0.7_format"
 
 [type_aws_spot_instance_request]
 50.0.0.17
+
+[type_azurerm_public_ip]
+50.0.0.20
 
 [type_cloudstack_instance]
 10.2.1.5

--- a/resource.go
+++ b/resource.go
@@ -20,7 +20,7 @@ func init() {
 		"public_ip",                        // AWS
 		"public_ipv6",                      // Scaleway
 		"ipaddress",                        // CS
-		"ip_address",                       // VMware, Docker, Linode
+		"ip_address",                       // VMware, Docker, Linode, Azure
 		"private_ip",                       // AWS
 		"network_interface.0.ipv4_address", // VMware
 		"default_ip_address",               // provider.vsphere v1.1.1
@@ -176,6 +176,15 @@ func (r Resource) Tags() map[string]string {
 		for k, v := range r.Attributes() {
 			parts := strings.SplitN(k, ".", 2)
 			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "%" {
+				kk := strings.ToLower(parts[1])
+				vv := strings.ToLower(v)
+				t[kk] = vv
+			}
+		}
+	case "azurerm_public_ip":
+		for k, v := range r.Attributes() {
+			parts := strings.SplitN(k, ".", 2)
+			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "#" && parts[1] != "%" {
 				kk := strings.ToLower(parts[1])
 				vv := strings.ToLower(v)
 				t[kk] = vv


### PR DESCRIPTION
The idea is to use [azurerm_public_ip](https://www.terraform.io/docs/providers/azurerm/r/public_ip.html) terraform resources, which are the place were public IP addresses are defined for Azure VMs.

For instance:

```terraform
resource "azurerm_public_ip" "cheap-worker-vm-ip" {
  name                = "cheap-worker-ip-address"
  location            = "${azurerm_resource_group.my-resource-group.location}"
  resource_group_name = "${azurerm_resource_group.my-resource-group.name}"
  allocation_method   = "Dynamic"

  tags = {
    Role = "cheap-worker"
  }
}
```

Will match later in ansible-playbook using the defined Role:

```yaml
---
- hosts: role_cheap-worker
  remote_user: ubuntu
  become: yes
  become_user: root
  tasks:
    - name: install apps
       apt: name=cowsay update_cache=yes
```