### PR TITLE
Add (proper) support for the Cherry servers provider

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -20,6 +20,7 @@ func init() {
 		"public_ip",                        // AWS
 		"public_ipv6",                      // Scaleway
 		"ipaddress",                        // CS
+		"primary_ip",                                          // Profitbricks, Cherry servers
 		"ip_address",                       // VMware, Docker, Linode
 		"private_ip",                       // AWS
 		"network_interface.0.ipv4_address", // VMware
@@ -34,7 +35,6 @@ func init() {
 		"primaryip",                                           // Joyent Triton
 		"network_interface.0.addresses.0",                     // Libvirt
 		"network.0.address",                                   // Packet
-		"primary_ip",                                          // Profitbricks
 		"nic_list.0.ip_endpoint_list.0.ip",                    // Nutanix
 	}
 


### PR DESCRIPTION
Cherryservers provider includes both private_ip & primary_ip attributes for servers. Make sure the latter is preferred when building an inventory.