### PR TITLE
ADD: first stab at openstack tag support

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -185,6 +185,8 @@ const exampleStateFile = `
 							"id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 							"access_ip_v4": "10.120.0.226",
 							"access_ip_v6": "",
+							"tag.%": "1",
+							"tag.tfinventory": "rocks",
 							"metadata.status": "superServer",
 							"metadata.#": "very bad",
 							"metadata_toes": "faada2142412jhb1j2"

--- a/resource.go
+++ b/resource.go
@@ -110,7 +110,11 @@ func (r Resource) Tags() map[string]string {
 			// At some point Terraform changed the key for counts of attributes to end with ".%"
 			// instead of ".#". Both need to be considered as Terraform still supports state
 			// files using the old format.
-			if len(parts) == 2 && parts[0] == "metadata" && parts[1] != "#" && parts[1] != "%" {
+			if len(parts) == 2 && parts[0] == "tag" && parts[1] != "#" && parts[1] != "%" {
+				kk := strings.ToLower(parts[1])
+				vv := strings.ToLower(v)
+				t[kk] = vv
+			} else if len(parts) == 2 && parts[0] == "metadata" && parts[1] != "#" && parts[1] != "%" {
 				kk := strings.ToLower(parts[1])
 				vv := strings.ToLower(v)
 				t[kk] = vv


### PR DESCRIPTION
Adding tag support to openstack instances.

Signed-off-by: Mark Sharpley <mcs94@cam.ac.uk>