### PR TITLE
Add note for Hetzner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following providers are supported:
 * Docker
 * Exoscale
 * Google Compute Engine
+* Hetzner Cloud
 * [libvirt](https://github.com/dmacvicar/terraform-provider-libvirt)
 * Linode
 * OpenStack

--- a/resource.go
+++ b/resource.go
@@ -16,7 +16,7 @@ var nameParser *regexp.Regexp
 
 func init() {
 	keyNames = []string{
-		"ipv4_address",                     // DO and SoftLayer
+		"ipv4_address",                     // DO and SoftLayer and HetznerCloud
 		"public_ip",                        // AWS
 		"public_ipv6",                      // Scaleway
 		"ipaddress",                        // CS


### PR DESCRIPTION
The Hetzner Cloud is already supported since it uses `ipv4_address` as well. 

This small PR simply adds a note to this in the code and docs, so people coming here will have this info directly.