### PR TITLE
Support default tags for the AWS Terraform provider.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -943,6 +943,9 @@ const exampleStateFileTerraform0dot12 = `
 						"tags": {
 							"Name": "one-aws-instance"
 						},
+						"tags_all": {
+							"Additional": "another-tag"
+						},
 						"volume_tags": {
 							"Ignored": "stuff"
 						}
@@ -1227,6 +1230,8 @@ const expectedListOutputTerraform0dot12 = `
 	"name_two-aws-instance": ["10.0.0.2"],
 	"name_three-aws-instance": ["10.0.0.3", "10.0.1.3"],
 
+	"additional_another-tag": ["35.159.25.34"],
+
 	"foo_bar": ["12.34.56.78"],
 	"type_vsphere_virtual_machine": ["12.34.56.78"],
 	"vm_0": ["12.34.56.78"],
@@ -1234,7 +1239,10 @@ const expectedListOutputTerraform0dot12 = `
 }
 `
 
-const expectedInventoryOutputTerraform0dot12 = `[all]
+const expectedInventoryOutputTerraform0dot12 = `[additional_another-tag]
+35.159.25.34
+
+[all]
 10.0.0.2
 10.0.0.3
 10.0.1.3
@@ -1307,6 +1315,8 @@ const expectedHostOneOutputTerraform0dot12 = `
 	"public_ip": "35.159.25.34",
 	"tags.#": "1",
 	"tags.Name": "one-aws-instance",
+	"tags_all.#": "1",
+	"tags_all.Additional": "another-tag",
 	"volume_tags.#":"1",
 	"volume_tags.Ignored":"stuff"
 }

--- a/parser_test.go.example.tfstate
+++ b/parser_test.go.example.tfstate
@@ -33,7 +33,10 @@
 						"private_ip": "10.0.0.1",
 						"public_ip": "35.159.25.34",
 						"tags": {
-							"Name": "one-aws-instance"
+							"Name": "one-aws-instance",
+						},
+						"tags_all": {
+							"Additional": "another-tag"
 						},
 						"volume_tags": {
 							"Ignored": "stuff"

--- a/resource.go
+++ b/resource.go
@@ -138,7 +138,7 @@ func (r Resource) Tags() map[string]string {
 			// At some point Terraform changed the key for counts of attributes to end with ".%"
 			// instead of ".#". Both need to be considered as Terraform still supports state
 			// files using the old format.
-			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "#" && parts[1] != "%" {
+			if len(parts) == 2 && (parts[0] == "tags" || parts[0] == "tags_all") && parts[1] != "#" && parts[1] != "%" {
 				kk := strings.ToLower(parts[1])
 				vv := strings.ToLower(v)
 				t[kk] = vv
@@ -150,7 +150,7 @@ func (r Resource) Tags() map[string]string {
 			// At some point Terraform changed the key for counts of attributes to end with ".%"
 			// instead of ".#". Both need to be considered as Terraform still supports state
 			// files using the old format.
-			if len(parts) == 2 && parts[0] == "tags" && parts[1] != "#" && parts[1] != "%" {
+			if len(parts) == 2 && (parts[0] == "tags" || parts[0] == "tags_all") && parts[1] != "#" && parts[1] != "%" {
 				kk := strings.ToLower(parts[1])
 				vv := strings.ToLower(v)
 				t[kk] = vv


### PR DESCRIPTION
In recent versions of the AWS Terraform provider, it is possible to attach default tags to every resource. Those tags aren't stored in the `tags` field in the Terraform state but as a special field `tags_all`. 

So this PR accepts tags for AWS resources from both fields to also export tags defined as default tags.

